### PR TITLE
Add a new function for creating java Extra instance.

### DIFF
--- a/src/java/mod.rs
+++ b/src/java/mod.rs
@@ -142,6 +142,17 @@ pub struct Extra<'el> {
 }
 
 impl<'el> Extra<'el> {
+    /// Create an Extra instance.
+    pub fn new<P>(package: P) -> Self
+    where
+        P: Into<Cons<'el>>,
+    {
+        Extra {
+            package: Some(package.into()),
+            imported: HashMap::new(),
+        }
+    }
+
     /// Set the package name to build.
     pub fn package<P>(&mut self, package: P)
     where


### PR DESCRIPTION
I want to call write_file in Java class, but Extra can't be created because of private field imported in Extra.
So, I added a new function to create Extra instance.
```
java::Java::write_file(class.into_tokens(), &mut formatter, &mut extra, 1)?;
```