### PR TITLE
Fix pattern parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+* Patterns are now parsed correctly to support alternatives separated by pipes (#12).
+
+[Unreleased]: https://github.com/udoprog/relative-path/compare/0.14.2...master

--- a/genco-macros/src/ast.rs
+++ b/genco-macros/src/ast.rs
@@ -6,6 +6,7 @@ use crate::static_buffer::StaticBuffer;
 
 /// A single match arm in a match statement.
 pub(crate) struct MatchArm {
+    pub(crate) attr: Vec<syn::Attribute>,
     pub(crate) pattern: syn::Pat,
     pub(crate) condition: Option<syn::Expr>,
     pub(crate) block: TokenStream,

--- a/genco-macros/src/encoder.rs
+++ b/genco-macros/src/encoder.rs
@@ -279,13 +279,14 @@ impl<'a> Encoder<'a> {
         let mut stream = TokenStream::new();
 
         for MatchArm {
+            attr,
             pattern,
             condition,
             block,
         } in arms
         {
             let condition = condition.map(|c| q::quote!(if #c));
-            stream.extend(q::quote!(#pattern #condition => { #block },));
+            stream.extend(q::quote!(#(#attr)* #pattern #condition => { #block },));
         }
 
         let m = q::quote! {

--- a/genco-macros/src/lib.rs
+++ b/genco-macros/src/lib.rs
@@ -428,23 +428,49 @@ mod token;
 /// use genco::prelude::*;
 ///
 /// # fn main() -> genco::fmt::Result {
-/// enum Greeting {
-///     Hello,
-///     Goodbye,
-/// }
-///
-/// fn greeting(greeting: Greeting, name: &str) -> Tokens<()> {
-///     quote!(Custom Greeting: #(match greeting {
-///         Greeting::Hello => Hello #name,
-///         Greeting::Goodbye => Goodbye #name,
+/// fn greeting(name: &str) -> Tokens<()> {
+///     quote!(Hello #(match name {
+///         "John" | "Jane" => #("Random Stranger"),
+///         other => #other,
 ///     }))
 /// }
 ///
-/// let tokens = greeting(Greeting::Hello, "John");
-/// assert_eq!("Custom Greeting: Hello John", tokens.to_string()?);
+/// let tokens = greeting("John");
+/// assert_eq!("Hello Random Stranger", tokens.to_string()?);
 ///
-/// let tokens = greeting(Greeting::Goodbye, "John");
-/// assert_eq!("Custom Greeting: Goodbye John", tokens.to_string()?);
+/// let tokens = greeting("Mio");
+/// assert_eq!("Hello Mio", tokens.to_string()?);
+/// # Ok(())
+/// # }
+/// ```
+/// 
+/// Example with more complex matching:
+///
+/// ```rust
+/// use genco::prelude::*;
+///
+/// # fn main() -> genco::fmt::Result {
+/// enum Greeting {
+///     Named(&'static str),
+///     Unknown,
+/// }
+///
+/// fn greeting(name: Greeting) -> Tokens<()> {
+///     quote!(Hello #(match name {
+///         Greeting::Named("John") | Greeting::Named("Jane") => #("Random Stranger"),
+///         Greeting::Named(other) => #other,
+///         Greeting::Unknown => #("Unknown Person"),
+///     }))
+/// }
+///
+/// let tokens = greeting(Greeting::Named("John"));
+/// assert_eq!("Hello Random Stranger", tokens.to_string()?);
+///
+/// let tokens = greeting(Greeting::Unknown);
+/// assert_eq!("Hello Unknown Person", tokens.to_string()?);
+///
+/// let tokens = greeting(Greeting::Named("Mio"));
+/// assert_eq!("Hello Mio", tokens.to_string()?);
 /// # Ok(())
 /// # }
 /// ```

--- a/genco-macros/src/quote_in.rs
+++ b/genco-macros/src/quote_in.rs
@@ -30,8 +30,6 @@ impl Parse for QuoteIn {
             #check
         }};
 
-        Ok(Self {
-            stream,
-        })
+        Ok(Self { stream })
     }
 }


### PR DESCRIPTION
Currently we only support native patterns in match statements.

This adds support for patterns with alternatives separated by pipes (`|`).