### PR TITLE
Add basic support for using genco to tokenize on stable

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on: [push, pull_request]
 
@@ -12,4 +12,8 @@ jobs:
         toolchain: nightly
         override: true
     - run: cargo test
+      env:
+        RUSTFLAGS: --cfg genco_nightly
     - run: cargo test --manifest-path=genco-macros/Cargo.toml
+      env:
+        RUSTFLAGS: --cfg genco_nightly

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-[![Build Status](https://github.com/udoprog/genco/workflows/Rust/badge.svg)](https://github.com/udoprog/genco/actions)
-[![crates.io](https://img.shields.io/crates/v/genco.svg)](https://crates.io/crates/genco)
-[![docs.rs](https://docs.rs/genco/badge.svg)](https://docs.rs/genco)
-
 # genco
+
+[<img alt="github" src="https://img.shields.io/badge/github-udoprog/genco-8da0cb?style=for-the-badge&logo=github" height="20">](https://github.com/udoprog/genco)
+[<img alt="crates.io" src="https://img.shields.io/crates/v/genco.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/genco)
+[<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-genco-66c2a5?style=for-the-badge&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/genco)
+[<img alt="build status" src="https://img.shields.io/github/workflow/status/udoprog/genco/CI/main?style=for-the-badge" height="20">](https://github.com/udoprog/genco/actions?query=branch%3Amain)
 
 A whitespace-aware quasiquoter for beautiful code generation.
 
@@ -30,14 +31,15 @@ This project solves the following language-specific concerns:
 
 <br>
 
-To do [whitespace detection], we depend on the nightly
-[`proc_macro_span` feature].
+To do [whitespace detection], we depend on the nightly [`proc_macro_span`
+feature] and that the `genco_nightly` configuration flag is set. Otherwise
+genco falls back to simply inserting spaces between each detected token.
 
-*Until this is stabilized*, you must build and run projects using genco
-with a `nightly` compiler.
+*Until this is stabilized* and you want whitespace detection you must build
+and run projects using genco with a `nightly` compiler.
 
 ```bash
-cargo +nightly run --example rust
+RUSTFLAGS="--cfg genco_nightly" cargo +nightly run --example rust
 ```
 
 [`proc_macro_span` feature]: https://github.com/rust-lang/rust/issues/54725
@@ -67,7 +69,8 @@ The following are languages which have built-in support in genco.
   <small>[Example][js-example]</small>
 
 * [🐍 <b>Python</b>][python]<br>
-  <small>[Example][python-example]</small>
+  <small>[Example][python-example]</small><br>
+  **Requires `--cfg genco_nightly`**
 
 <small>Is your favorite language missing? <b>[Open an issue!]</b></small>
 
@@ -138,3 +141,5 @@ fn main() {
 [impl_lang!]: https://docs.rs/genco/0/genco/macro.impl_lang.html
 [quoted()]: https://docs.rs/genco/0/genco/tokens/fn.quoted.html
 [Open an issue!]: https://github.com/udoprog/genco/issues/new
+
+License: MIT/Apache-2.0

--- a/README.tpl
+++ b/README.tpl
@@ -1,7 +1,0 @@
-[![Build Status](https://github.com/udoprog/genco/workflows/Rust/badge.svg)](https://github.com/udoprog/genco/actions)
-[![crates.io](https://img.shields.io/crates/v/genco.svg)](https://crates.io/crates/genco)
-[![docs.rs](https://docs.rs/genco/badge.svg)](https://docs.rs/genco)
-
-# {{crate}}
-
-{{readme}}

--- a/genco-macros/src/cursor.rs
+++ b/genco-macros/src/cursor.rs
@@ -18,6 +18,7 @@ impl Cursor {
     /// Check that the cursor is not a mock cursor.
     ///
     /// See: https://github.com/alexcrichton/proc-macro2/issues/237
+    #[cfg(genco_nightly)]
     pub(crate) fn check_compat(&self) -> syn::Result<()> {
         if self.start.line == 0
             && self.start.column == 0

--- a/genco-macros/src/lib.rs
+++ b/genco-macros/src/lib.rs
@@ -24,6 +24,10 @@ mod token;
 ///
 /// It provides a flexible and intuitive mechanism for efficiently generating
 /// beautiful code directly inside of Rust.
+/// 
+/// > Note that this macro **is only whitespace sensitive** if the
+/// > `genco_nightly` configuration flag is enabled, and you are building on a
+/// > nightly compiler. See the [main genco documentation] for more information.
 ///
 /// ```rust
 /// use genco::prelude::*;
@@ -120,6 +124,7 @@ mod token;
 /// ```
 ///
 /// [FormatInto]: https://docs.rs/genco/0/genco/tokens/trait.FormatInto.html
+/// [main genco documentation]: https://docs.rs/genco
 ///
 /// <br>
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! [<img alt="github" src="https://img.shields.io/badge/github-udoprog/genco-8da0cb?style=for-the-badge&logo=github" height="20">](https://github.com/udoprog/genco)
+//! [<img alt="crates.io" src="https://img.shields.io/crates/v/genco.svg?style=for-the-badge&color=fc8d62&logo=rust" height="20">](https://crates.io/crates/genco)
+//! [<img alt="docs.rs" src="https://img.shields.io/badge/docs.rs-genco-66c2a5?style=for-the-badge&logoColor=white&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K" height="20">](https://docs.rs/genco)
+//! [<img alt="build status" src="https://img.shields.io/github/workflow/status/udoprog/genco/CI/main?style=for-the-badge" height="20">](https://github.com/udoprog/genco/actions?query=branch%3Amain)
+//!
 //! A whitespace-aware quasiquoter for beautiful code generation.
 //!
 //! Central to genco are the [quote!] and [quote_in!] procedural macros which
@@ -24,14 +29,15 @@
 //!
 //! <br>
 //!
-//! To do [whitespace detection], we depend on the nightly
-//! [`proc_macro_span` feature].
+//! To do [whitespace detection], we depend on the nightly [`proc_macro_span`
+//! feature] and that the `genco_nightly` configuration flag is set. Otherwise
+//! genco falls back to simply inserting spaces between each detected token.
 //!
-//! *Until this is stabilized*, you must build and run projects using genco
-//! with a `nightly` compiler.
+//! *Until this is stabilized* and you want whitespace detection you must build
+//! and run projects using genco with a `nightly` compiler.
 //!
 //! ```bash
-//! cargo +nightly run --example rust
+//! RUSTFLAGS="--cfg genco_nightly" cargo +nightly run --example rust
 //! ```
 //!
 //! [`proc_macro_span` feature]: https://github.com/rust-lang/rust/issues/54725
@@ -61,7 +67,8 @@
 //!   <small>[Example][js-example]</small>
 //!
 //! * [🐍 <b>Python</b>][python]<br>
-//!   <small>[Example][python-example]</small>
+//!   <small>[Example][python-example]</small><br>
+//!   **Requires `--cfg genco_nightly`**
 //!
 //! <small>Is your favorite language missing? <b>[Open an issue!]</b></small>
 //!
@@ -138,7 +145,7 @@
 
 #![doc(html_root_url = "https://docs.rs/genco/0.15.0")]
 #![deny(missing_docs)]
-#![deny(broken_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
 
 pub use genco_macros::{quote, quote_fn, quote_in};
 


### PR DESCRIPTION
This forces whitespace detection behind a configuration flag that needs to be activated through `RUSTFLAGS="--cfg genco_nightly"`, otherwise it falls back to performing a tokenization similar to [quote].

This is a breaking change intending to allow `genco` to be used on stable, but it then won't work for whitespace sensitive languages like `python`. Projects can still benefit performance-wise from the way that genco performs code generation which would allow for fewer allocations.

[quote]: https://docs.rs/quote