### PR TITLE
Fix incorrect use of joint tokens (#21)

### DIFF
--- a/genco-macros/src/encoder.rs
+++ b/genco-macros/src/encoder.rs
@@ -61,21 +61,11 @@ impl<'a> Encoder<'a> {
         #[cfg(genco_nightly)]
         cursor.check_compat()?;
 
-        // NB: only join tokens.
-        self.joint = match &ast {
-            Ast::Tree { tt: TokenTree::Punct(..), .. } => self.joint,
-            _ => false,
-        };
-
         self.step(cursor, span)?;
 
         match ast {
             Ast::Tree { tt, .. } => {
-                self.joint = match &tt {
-                    TokenTree::Punct(p) => matches!(p.spacing(), Spacing::Joint),
-                    __ => false,
-                };
-
+                self.joint = matches!(&tt, TokenTree::Punct(p) if matches!(p.spacing(), Spacing::Joint));
                 self.encode_literal(&tt.to_string());
             }
             Ast::String { has_eval, stream } => {

--- a/src/lang/rust.rs
+++ b/src/lang/rust.rs
@@ -140,6 +140,7 @@ impl_lang! {
 /// Format state for Rust.
 #[derive(Debug, Default)]
 pub struct Format {}
+
 /// Language configuration for Rust.
 #[derive(Debug)]
 pub struct Config {


### PR DESCRIPTION
The issue with joint tokens was actually a misguided attempt at generating better looking code. This fixes it.

Closes #21