### PR TITLE
Move parser to solely use $ for variables for 2021 edition support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
       with:
         toolchain: nightly
         override: true
-    - run: cargo test
-      env:
-        RUSTFLAGS: --cfg genco_nightly
-    - run: cargo test --manifest-path=genco-macros/Cargo.toml
+    - run: cargo +nightly test --all --workspace
       env:
         RUSTFLAGS: --cfg genco_nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0]
+
+### Added
+* Added `FormatInto` implementation for `Arguments<'_>` ([#26]).
+
+### Changed
+* All syntax has been changed from using `#` to `$` ([#27]).
+
+[#26]: https://github.com/udoprog/genco/issues/26
+[#27]: https://github.com/udoprog/genco/issues/27
+[0.17.0]: https://github.com/udoprog/genco/compare/0.16.0...0.17.0
+
 ## [0.16.0]
 
 ### Changed
@@ -45,4 +57,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.15.0]: https://github.com/udoprog/genco/compare/0.14.2...0.15.0
 [0.15.1]: https://github.com/udoprog/genco/compare/0.15.0...0.15.1
 [0.16.0]: https://github.com/udoprog/genco/compare/0.15.1...0.16.0
-[Unreleased]: https://github.com/udoprog/genco/compare/0.16.0...master
+[Unreleased]: https://github.com/udoprog/genco/compare/0.17.0...master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ A whitespace-aware quasiquoter for beautiful code generation.
 """
 
 [dependencies]
-genco-macros = {path = "genco-macros", version = "0.16.1"}
+genco-macros = {path = "./genco-macros", version = "0.16.1"}
+
 relative-path = "1.2.0"
 smallvec = "1.4.0"
 
 [dev-dependencies]
 anyhow = "1.0.31"
 rand = "0.7.3"
+
+[workspace]
+members = ["genco-macros"]

--- a/examples/csharp.rs
+++ b/examples/csharp.rs
@@ -17,35 +17,35 @@ fn main() -> anyhow::Result<()> {
     let tokens = quote! {
         public class Test {
             public static void Main()  {
-                #(comment(&["Creates a new TestSimpleObject object."]))
-                #simple_object obj = new #simple_object();
+                $(comment(&["Creates a new TestSimpleObject object."]))
+                $simple_object obj = new $simple_object();
 
-                #console.WriteLine("Before serialization the object contains: ");
+                $console.WriteLine("Before serialization the object contains: ");
                 obj.Print();
 
-                #(comment(&["Opens a file and serializes the object into it in binary format."]))
-                #stream stream = #file.Open("data.xml", FileMode.Create);
-                #soap_formatter formatter = new #soap_formatter();
+                $(comment(&["Opens a file and serializes the object into it in binary format."]))
+                $stream stream = $file.Open("data.xml", FileMode.Create);
+                $soap_formatter formatter = new $soap_formatter();
 
-                #(comment(&["BinaryFormatter formatter = new BinaryFormatter();"]))
+                $(comment(&["BinaryFormatter formatter = new BinaryFormatter();"]))
 
                 formatter.Serialize(stream, obj);
                 stream.Close();
 
-                #(comment(&["Empties obj."]))
+                $(comment(&["Empties obj."]))
                 obj = null;
 
-                #(comment(&["Opens file \"data.xml\" and deserializes the object from it."]))
-                stream = #file.Open("data.xml", FileMode.Open);
-                formatter = new #soap_formatter();
+                $(comment(&["Opens file \"data.xml\" and deserializes the object from it."]))
+                stream = $file.Open("data.xml", FileMode.Open);
+                formatter = new $soap_formatter();
 
-                #(comment(&["formatter = new BinaryFormatter();"]))
+                $(comment(&["formatter = new BinaryFormatter();"]))
 
-                obj = (#simple_object)formatter.Deserialize(stream);
+                obj = ($simple_object)formatter.Deserialize(stream);
                 stream.Close();
 
-                #console.WriteLine("");
-                #console.WriteLine("After deserialization the object contains: ");
+                $console.WriteLine("");
+                $console.WriteLine("After deserialization the object contains: ");
                 obj.Print();
             }
         }

--- a/examples/dart.rs
+++ b/examples/dart.rs
@@ -6,11 +6,11 @@ fn main() -> anyhow::Result<()> {
 
     let tokens = quote! {
         print_greeting(String name) {
-            print(#_(Hello $(name)));
+            print($[str](Hello $(name)));
         }
 
-        #hash_map<int, String> map() {
-            return new #hash_map<int, String>();
+        $hash_map<int, String> map() {
+            return new $hash_map<int, String>();
         }
     };
 

--- a/examples/go.rs
+++ b/examples/go.rs
@@ -10,13 +10,13 @@ fn main() -> anyhow::Result<()> {
     let tokens = quote! {
         func main() {
             var currentDay string
-            currentDay = #(quoted(day))
-            #println(currentDay)
-            #println(greetUser())
+            currentDay = $(quoted(day))
+            $println(currentDay)
+            $println(greetUser())
         }
 
         func greetUser() string {
-            return #(quoted(format!("Hello {}!", name)))
+            return $(quoted(format!("Hello {}!", name)))
         }
     };
 

--- a/examples/java.rs
+++ b/examples/java.rs
@@ -9,12 +9,12 @@ fn main() -> anyhow::Result<()> {
     let tokens = quote! {
         public class HelloWorld {
             public static void main(String[] args) {
-                #list<#car> cars = new #array_list<#car>();
+                $list<$car> cars = new $array_list<$car>();
 
-                cars.add(new #car("Volvo"));
-                cars.add(new #car("Audi"));
+                cars.add(new $car("Volvo"));
+                cars.add(new $car("Audi"));
 
-                for (#car car : cars) {
+                for ($car car : cars) {
                     System.out.println(car);
                 }
             }

--- a/examples/js.rs
+++ b/examples/js.rs
@@ -8,7 +8,7 @@ fn main() -> anyhow::Result<()> {
     let calculate = &js::import("../logic/calculate", "calculate").into_default();
 
     let tokens = quote! {
-        export default class App extends #react.Component {
+        export default class App extends $react.Component {
             state = {
                 total: null,
                 next: null,
@@ -16,14 +16,14 @@ fn main() -> anyhow::Result<()> {
             };
 
             handleClick = buttonName => {
-                this.setState(#calculate(this.state, buttonName));
+                this.setState($calculate(this.state, buttonName));
             };
 
             render() {
                 return (
                     <div className="component-app">
-                        <#display value={this.state.next || this.state.total || "0"} />
-                        <#button_panel clickHandler={this.handleClick} />
+                        <$display value={this.state.next || this.state.total || "0"} />
+                        <$button_panel clickHandler={this.handleClick} />
                     </div>
                 );
             }

--- a/examples/python.rs
+++ b/examples/python.rs
@@ -5,7 +5,7 @@ fn main() -> anyhow::Result<()> {
     let flask = &python::import("flask", "Flask");
 
     let tokens = quote! {
-        app = #flask(__name__)
+        app = $flask(__name__)
 
         @app.route('/')
         def hello():

--- a/examples/rust.rs
+++ b/examples/rust.rs
@@ -14,12 +14,12 @@ fn main() -> anyhow::Result<()> {
     let result = rust::import("anyhow", "Result");
 
     let tokens = quote! {
-        #(register(write_bytes_ext))
+        $(register(write_bytes_ext))
 
-        fn test() -> #result {
+        fn test() -> $result {
             let mut data = vec![];
-            data.write_u16::<#little_endian>(517)?;
-            data.write_u16::<#big_endian>(768)?;
+            data.write_u16::<$little_endian>(517)?;
+            data.write_u16::<$big_endian>(768)?;
             println!("{:?}", data);
         }
     };

--- a/genco-macros/src/encoder.rs
+++ b/genco-macros/src/encoder.rs
@@ -2,7 +2,7 @@ use crate::ast::{Ast, Control, ControlKind, Delimiter, MatchArm};
 use crate::cursor::Cursor;
 use crate::requirements::Requirements;
 use crate::static_buffer::StaticBuffer;
-use proc_macro2::{LineColumn, Span, TokenStream, TokenTree, Spacing};
+use proc_macro2::{LineColumn, Spacing, Span, TokenStream, TokenTree};
 use syn::Result;
 
 /// Struct to deal with emitting the necessary spacing.
@@ -65,7 +65,8 @@ impl<'a> Encoder<'a> {
 
         match ast {
             Ast::Tree { tt, .. } => {
-                self.joint = matches!(&tt, TokenTree::Punct(p) if matches!(p.spacing(), Spacing::Joint));
+                self.joint =
+                    matches!(&tt, TokenTree::Punct(p) if matches!(p.spacing(), Spacing::Joint));
                 self.encode_literal(&tt.to_string());
             }
             Ast::String { has_eval, stream } => {
@@ -362,12 +363,7 @@ impl<'a> Encoder<'a> {
     /// If we are not in a nightly genco, simply tokenize the output separated
     /// by spaces.
     #[cfg(not(genco_nightly))]
-    fn tokenize_whitespace(
-        &mut self,
-        _: LineColumn,
-        _: LineColumn,
-        _: Option<Span>,
-    ) -> Result<()> {
+    fn tokenize_whitespace(&mut self, _: LineColumn, _: LineColumn, _: Option<Span>) -> Result<()> {
         use std::mem;
 
         if !mem::take(&mut self.joint) {
@@ -452,8 +448,12 @@ impl<'a> Encoder<'a> {
         }
 
         return Ok(());
- 
-        fn indentation_error(to_column: usize, from_column: usize, to_span: Option<Span>) -> syn::Error {
+
+        fn indentation_error(
+            to_column: usize,
+            from_column: usize,
+            to_span: Option<Span>,
+        ) -> syn::Error {
             let error = if to_column > from_column {
                 let len = to_column.saturating_sub(from_column);
 

--- a/genco-macros/src/lib.rs
+++ b/genco-macros/src/lib.rs
@@ -24,7 +24,7 @@ mod token;
 ///
 /// It provides a flexible and intuitive mechanism for efficiently generating
 /// beautiful code directly inside of Rust.
-/// 
+///
 /// > Note that this macro **is only whitespace sensitive** if the
 /// > `genco_nightly` configuration flag is enabled, and you are building on a
 /// > nightly compiler. See the [main genco documentation] for more information.
@@ -37,11 +37,11 @@ mod token;
 ///
 /// let tokens: dart::Tokens = quote! {
 ///     print_greeting(String name) {
-///         print(#_(Hello $(name)));
+///         print($[str](Hello $(name)));
 ///     }
 ///
-///     #hash_map<int, String> map() {
-///         return new #hash_map<int, String>();
+///     $hash_map<int, String> map() {
+///         return new $hash_map<int, String>();
 ///     }
 /// };
 ///
@@ -54,7 +54,7 @@ mod token;
 ///
 /// Variables are interpolated using `#`, so to include the variable `test`, you
 /// would write `#test`. Interpolated variables must implement [FormatInto].
-/// Expressions can be interpolated with `#(<expr>)`.
+/// Expressions can be interpolated with `$(<expr>)`.
 ///
 /// > *Note:* The `#` punctuation itself can be escaped by repeating it twice.
 /// > So `##` would produce a single `#` token.
@@ -67,7 +67,7 @@ mod token;
 ///
 /// let tokens: rust::Tokens = quote! {
 ///     struct Quoted {
-///         field: #hash_map<u32, u32>,
+///         field: $hash_map<u32, u32>,
 ///     }
 /// };
 ///
@@ -87,7 +87,7 @@ mod token;
 ///
 /// <br>
 ///
-/// The following is an expression interpolated with `#(<expr>)`.
+/// The following is an expression interpolated with `$(<expr>)`.
 ///
 /// ```rust
 /// use genco::prelude::*;
@@ -95,7 +95,7 @@ mod token;
 /// # fn main() -> genco::fmt::Result {
 ///
 /// let tokens: genco::Tokens = quote! {
-///     hello #("world".to_uppercase())
+///     hello $("world".to_uppercase())
 /// };
 ///
 /// assert_eq!("hello WORLD", tokens.to_string()?);
@@ -117,7 +117,7 @@ mod token;
 /// fn age_fn(age: &str) -> Result<rust::Tokens, Box<dyn Error>> {
 ///     Ok(quote! {
 ///         fn age() {
-///             println!("You are {} years old!", #(str::parse::<u32>(age)?));
+///             println!("You are {} years old!", $(str::parse::<u32>(age)?));
 ///         }
 ///     })
 /// }
@@ -135,19 +135,19 @@ mod token;
 ///
 /// `quote!` trims any trailing and leading whitespace that it sees. So
 /// `quote!(Hello )` is the same as `quote!(Hello)`. To include a space at the
-/// end, we can use the special `#<space>` escape sequence:
-/// `quote!(Hello#<space>)`.
+/// end, we can use the special `$[' ']` escape sequence:
+/// `quote!(Hello$[' '])`.
 ///
 /// The available escape sequences are:
 ///
-/// * `#<space>` — Inserts a space between tokens. This corresponds to the
+/// * `$[' ']` — Inserts spacing between tokens. This corresponds to the
 ///   [Tokens::space] function.
 ///
-/// * `#<push>` — Inserts a push operation. Push operations makes sure that
+/// * `$['\r']` — Inserts a push operation. Push operations makes sure that
 ///   any following tokens are on their own dedicated line. This corresponds to
 ///   the [Tokens::push] function.
 ///
-/// * `#<line>` — Inserts a forced line. Line operations makes sure that any
+/// * `$['\n']` — Inserts a forced line. Line operations makes sure that any
 ///   following tokens have an empty line separating them. This corresponds to
 ///   the [Tokens::line] function.
 ///
@@ -157,7 +157,7 @@ mod token;
 /// # fn main() -> genco::fmt::Result {
 /// let numbers = 3..=5;
 ///
-/// let tokens: Tokens<()> = quote!(foo#<push>bar#<line>baz#<space>biz);
+/// let tokens: Tokens<()> = quote!(foo$['\r']bar$['\n']baz$[' ']biz);
 ///
 /// assert_eq!("foo\nbar\n\nbaz biz", tokens.to_string()?);
 /// # Ok(())
@@ -183,9 +183,9 @@ mod token;
 /// # fn main() -> genco::fmt::Result {
 /// let tokens: java::Tokens = quote! {
 ///     "hello world 😊"
-///     #(quoted("hello world 😊"))
-///     #("\"hello world 😊\"")
-///     #_(hello world #("😊"))
+///     $(quoted("hello world 😊"))
+///     $("\"hello world 😊\"")
+///     $[str](hello world $[const]("😊"))
 /// };
 ///
 /// assert_eq!(
@@ -213,7 +213,7 @@ mod token;
 ///   entirely.
 /// * Finally the fourth one is an interpolated string. They are really neat,
 ///   and will be covered more in the next section. It's worth noting that
-///   `#("😊")` is used, because 😊 is not a valid identifier in Rust. So this
+///   `$("😊")` is used, because 😊 is not a valid identifier in Rust. So this
 ///   example showcases how strings can be directly embedded in an
 ///   interpolation.
 ///
@@ -224,9 +224,9 @@ mod token;
 /// # fn main() -> genco::fmt::Result {
 /// # let tokens: rust::Tokens = quote! {
 /// #     "hello world 😊"
-/// #     #(quoted("hello world 😊"))
-/// #     #("\"hello world 😊\"")
-/// #     #_(hello world #("😊"))
+/// #     $(quoted("hello world 😊"))
+/// #     $("\"hello world 😊\"")
+/// #     $[str](hello world $[const]("😊"))
 /// # };
 /// #
 /// use genco::tokens::{Item, ItemStr};
@@ -266,9 +266,23 @@ mod token;
 /// * Dart - With [interpolated strings] like `"Hello $a"` or `"Hello ${a +
 ///   b}"`.
 ///
-/// The [quote!] macro supports this through `#_(<content>)`. This will produce
-/// literal strings with the appropriate language-specific quoting and string
-/// interpolation formats used.
+/// The [quote!] macro supports this through `$[str](<content>)`. This will
+/// produce literal strings with the appropriate language-specific quoting and
+/// string interpolation formats used.
+///
+/// Components of the string are runtime evaluated with the typical variable
+/// escape sequences `$ident`, `$(<expr>)`. In order to interpolate the string
+/// at compile time we can instead make use of `$[const](<content>)` like you can see with the smile below:
+///
+/// ```
+/// use genco::prelude::*;
+///
+/// let smile = "😊";
+///
+/// let t: js::Tokens = quote!($[str](Hello $[const](smile) $world));
+/// assert_eq!("`Hello 😊 ${world}`", t.to_string()?);
+/// # Ok::<_, genco::fmt::Error>(())
+/// ```
 ///
 /// Interpolated values are specified with `$(<quoted>)`. And `$` itself is
 /// escaped by repeating it twice through `$$`. The `<quoted>` section is
@@ -276,23 +290,19 @@ mod token;
 /// This means that `$(foo)` is not the same as `$(foo )` since the latter will
 /// have a space preserved at the end.
 ///
-/// Raw items can be interpolated with `#(<expr>)` or `#<ident>`. Escaping `#`
-/// is done similarly with `##`. Note that [control flow](#control-flow) is
-/// *not* supported inside of quoted strings.
-///
 /// ```rust
 /// use genco::prelude::*;
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let smile = "😊";
 ///
-/// let t: dart::Tokens = quote!(#_(Hello #smile $(world)));
+/// let t: dart::Tokens = quote!($[str](Hello $[const](smile) $(world)));
 /// assert_eq!("\"Hello 😊 $world\"", t.to_string()?);
 ///
-/// let t: dart::Tokens = quote!(#_(Hello #smile $(a + b)));
+/// let t: dart::Tokens = quote!($[str](Hello $[const](smile) $(a + b)));
 /// assert_eq!("\"Hello 😊 ${a + b}\"", t.to_string()?);
 ///
-/// let t: js::Tokens = quote!(#_(Hello #smile $(world)));
+/// let t: js::Tokens = quote!($[str](Hello $[const](smile) $(world)));
 /// assert_eq!("`Hello 😊 ${world}`", t.to_string()?);
 /// # Ok(())
 /// # }
@@ -308,18 +318,18 @@ mod token;
 /// [quote!] provides some limited mechanisms for control flow inside of the
 /// macro for convenience. The supported mechanisms are:
 ///
-/// * [Loops](#loops) - `#(for <bindings> in <expr> [join (<quoted>)] => <quoted>)`.
-/// * [Conditionals](#conditionals) - `#(if <pattern> => <quoted>)`.
-/// * [Match Statements](#match-statements) - `#(match <expr> { [<pattern> => <quoted>,]* })`.
+/// * [Loops](#loops) - `$(for <bindings> in <expr> [join (<quoted>)] => <quoted>)`.
+/// * [Conditionals](#conditionals) - `$(if <pattern> => <quoted>)`.
+/// * [Match Statements](#match-statements) - `$(match <expr> { [<pattern> => <quoted>,]* })`.
 ///
 /// <br>
 ///
 /// # Loops
 ///
-/// To repeat a pattern you can use `#(for <bindings> in <expr> { <quoted> })`,
+/// To repeat a pattern you can use `$(for <bindings> in <expr> { <quoted> })`,
 /// where `<expr>` is an iterator.
 ///
-/// It is also possible to use the more compact `#(for <bindings> in <expr> =>
+/// It is also possible to use the more compact `$(for <bindings> in <expr> =>
 /// <quoted>)` (note the arrow).
 ///
 /// `<quoted>` will be treated as a quoted expression, so anything which works
@@ -333,7 +343,7 @@ mod token;
 /// let numbers = 3..=5;
 ///
 /// let tokens: Tokens<()> = quote! {
-///     Your numbers are: #(for n in numbers => #n#<space>)
+///     Your numbers are: $(for n in numbers => $n$[' '])
 /// };
 ///
 /// assert_eq!("Your numbers are: 3 4 5", tokens.to_string()?);
@@ -361,7 +371,7 @@ mod token;
 /// let numbers = 3..=5;
 ///
 /// let tokens: Tokens<()> = quote! {
-///     Your numbers are: #(for n in numbers join (, ) => #n).
+///     Your numbers are: $(for n in numbers join (, ) => $n).
 /// };
 ///
 /// assert_eq!("Your numbers are: 3, 4, 5.", tokens.to_string()?);
@@ -375,12 +385,12 @@ mod token;
 ///
 /// # Conditionals
 ///
-/// You can specify a conditional with `#(if <pattern> => <then>)` where
+/// You can specify a conditional with `$(if <pattern> => <then>)` where
 /// <pattern> is an pattern or expression evaluating to a `bool`, and `<then>`
 /// is a quoted expressions.
 ///
 /// It's also possible to specify a condition with an else branch, by using
-/// `#(if <pattern> { <then> } else { <else> })`. `<else>` is also a quoted
+/// `$(if <pattern> { <then> } else { <else> })`. `<else>` is also a quoted
 /// expression.
 ///
 /// ```rust
@@ -388,10 +398,10 @@ mod token;
 ///
 /// # fn main() -> genco::fmt::Result {
 /// fn greeting(hello: bool, name: &str) -> Tokens<()> {
-///     quote!(Custom Greeting: #(if hello {
-///         Hello #name
+///     quote!(Custom Greeting: $(if hello {
+///         Hello $name
 ///     } else {
-///         Goodbye #name
+///         Goodbye $name
 ///     }))
 /// }
 ///
@@ -414,8 +424,8 @@ mod token;
 ///
 /// # fn main() -> genco::fmt::Result {
 /// fn greeting(hello: bool, name: &str) -> Tokens<()> {
-///     quote!(Custom Greeting:#(if hello {
-///         #<space>Hello #name
+///     quote!(Custom Greeting:$(if hello {
+///         $[' ']Hello $name
 ///     }))
 /// }
 ///
@@ -432,19 +442,19 @@ mod token;
 ///
 /// # Match Statements
 ///
-/// You can specify a match expression using `#(match <expr> { [<pattern> =>
+/// You can specify a match expression using `$(match <expr> { [<pattern> =>
 /// <quoted>,]* }`, where `<expr>` is an evaluated expression that is match
 /// against each subsequent `<pattern>`. If a pattern matches, the arm with the
 /// matching `<quoted>` block is evaluated.
-/// 
+///
 /// ```rust
 /// use genco::prelude::*;
 ///
 /// # fn main() -> genco::fmt::Result {
 /// fn greeting(name: &str) -> Tokens<()> {
-///     quote!(Hello #(match name {
-///         "John" | "Jane" => #("Random Stranger"),
-///         other => #other,
+///     quote!(Hello $(match name {
+///         "John" | "Jane" => $("Random Stranger"),
+///         other => $other,
 ///     }))
 /// }
 ///
@@ -466,9 +476,9 @@ mod token;
 ///
 /// # fn main() -> genco::fmt::Result {
 /// fn greeting(name: &str) -> Tokens<()> {
-///     quote!(Hello#(match name {
-///         "John" | "Jane" => ( #("Random Stranger")),
-///         other => ( #other),
+///     quote!(Hello$(match name {
+///         "John" | "Jane" => ( $("Random Stranger")),
+///         other => ( $other),
 ///     }))
 /// }
 ///
@@ -493,10 +503,10 @@ mod token;
 /// }
 ///
 /// fn greeting(name: Greeting) -> Tokens<()> {
-///     quote!(Hello #(match name {
-///         Greeting::Named("John") | Greeting::Named("Jane") => #("Random Stranger"),
-///         Greeting::Named(other) => #other,
-///         Greeting::Unknown => #("Unknown Person"),
+///     quote!(Hello $(match name {
+///         Greeting::Named("John") | Greeting::Named("Jane") => $("Random Stranger"),
+///         Greeting::Named(other) => $other,
+///         Greeting::Unknown => $("Unknown Person"),
 ///     }))
 /// }
 ///
@@ -516,12 +526,12 @@ mod token;
 ///
 /// # Scopes
 ///
-/// You can use `#(ref <binding> { <expr> })` to gain access to the current
+/// You can use `$(ref <binding> { <expr> })` to gain access to the current
 /// token stream. This is an alternative to existing control flow operators if
 /// you want to run some custom code during evaluation which is otherwise not
 /// supported. This is called a *scope*.
 ///
-/// For a more compact variant you can omit the braces with `#(ref <binding> =>
+/// For a more compact variant you can omit the braces with `$(ref <binding> =>
 /// <expr>)`.
 ///
 /// ```rust
@@ -530,7 +540,7 @@ mod token;
 /// # fn main() -> genco::fmt::Result {
 /// fn quote_greeting(surname: &str, lastname: Option<&str>) -> rust::Tokens {
 ///     quote! {
-///         Hello #surname#(ref toks {
+///         Hello $surname$(ref toks {
 ///             if let Some(lastname) = lastname {
 ///                 toks.space();
 ///                 toks.append(lastname);
@@ -554,7 +564,7 @@ mod token;
 ///
 /// **Spaces** — Two tokens that are separated are spaced. Regardless of how
 /// many spaces there are between them. This can be controlled manually by
-/// inserting the [`#<space>`] escape sequence in the token stream.
+/// inserting the [`$[' ']`] escape sequence in the token stream.
 ///
 /// ```rust
 /// use genco::prelude::*;
@@ -586,7 +596,7 @@ mod token;
 ///
 /// **Line breaking** — Line breaks are detected by leaving two empty lines
 /// between two tokens. This can be controlled manually by inserting the
-/// [`#<line>`] escape in the token stream.
+/// [`$['\n']`] escape in the token stream.
 ///
 /// ```rust
 /// use genco::prelude::*;
@@ -678,8 +688,8 @@ mod token;
 ///    |         ^^^^^^^
 /// ```
 ///
-/// [`#<space>`]: #escape-sequences
-/// [`#<line>`]: #escape-sequences
+/// [`$[' ']`]: #escape-sequences
+/// [`$['\n']`]: #escape-sequences
 #[proc_macro]
 pub fn quote(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let receiver = &syn::Ident::new("__genco_macros_toks", Span::call_site());
@@ -762,7 +772,7 @@ pub fn quote(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// let tokens: rust::Tokens = quote! {
 ///     fn foo(v: bool) -> u32 {
-///         #(ref out {
+///         $(ref out {
 ///             quote_in! { *out =>
 ///                 if v {
 ///                     1
@@ -813,8 +823,8 @@ pub fn quote_in(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// };
 ///
 /// let tokens: rust::Tokens = quote!{
-///     #f1
-///     #f2
+///     $f1
+///     $f2
 /// };
 ///
 /// assert_eq!{
@@ -836,19 +846,19 @@ pub fn quote_in(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// # fn main() -> genco::fmt::Result {
 /// fn greeting(name: &str) -> impl FormatInto<Rust> + '_ {
 ///     quote_fn! {
-///         println!(#_(Hello #name))
+///         println!($[str](Hello $[const](name)))
 ///     }
 /// }
 ///
 /// fn advanced_greeting<'a>(first: &'a str, last: &'a str) -> impl FormatInto<Rust> + 'a {
 ///     quote_fn! {
-///         println!(#_(Hello #first #last))
+///         println!($[str](Hello $[const](first) $[const](last)))
 ///     }
 /// }
 ///
 /// let tokens = quote! {
-///     #(greeting("Mio"));
-///     #(advanced_greeting("Jane", "Doe"));
+///     $(greeting("Mio"));
+///     $(advanced_greeting("Jane", "Doe"));
 /// };
 ///
 /// assert_eq!{

--- a/src/fmt/fmt_writer.rs
+++ b/src/fmt/fmt_writer.rs
@@ -13,7 +13,7 @@ use crate::fmt;
 /// let map = rust::import("std::collections", "HashMap");
 ///
 /// let tokens: rust::Tokens = quote! {
-///     let mut m = #map::new();
+///     let mut m = $map::new();
 ///     m.insert(1u32, 2u32);
 /// };
 ///

--- a/src/fmt/formatter.rs
+++ b/src/fmt/formatter.rs
@@ -178,7 +178,7 @@ impl<'a> Formatter<'a> {
                     L::open_quote(self, config, format, *has_eval)?;
                 }
                 // Warning: slow path which will buffer a string internally.
-                // This is used for expressions like: `#_(Hello #(quoted(world)))`.
+                // This is used for expressions like: `$[str](Hello $(quoted(world)))`.
                 //
                 // Evaluating quotes are not supported.
                 Item::OpenQuote(false) if *in_quote => {

--- a/src/fmt/io_writer.rs
+++ b/src/fmt/io_writer.rs
@@ -14,7 +14,7 @@ use std::io;
 /// let map = rust::import("std::collections", "HashMap");
 ///
 /// let tokens: rust::Tokens = quote! {
-///     let mut m = #map::new();
+///     let mut m = $map::new();
 ///     m.insert(1u32, 2u32);
 /// };
 ///

--- a/src/fmt/vec_writer.rs
+++ b/src/fmt/vec_writer.rs
@@ -12,7 +12,7 @@ use crate::fmt;
 /// let map = rust::import("std::collections", "HashMap");
 ///
 /// let tokens: rust::Tokens = quote! {
-///     let mut m = #map::new();
+///     let mut m = $map::new();
 ///     m.insert(1u32, 2u32);
 /// };
 ///

--- a/src/lang/csharp/mod.rs
+++ b/src/lang/csharp/mod.rs
@@ -58,8 +58,8 @@ impl_lang! {
 
             if let Some(namespace) = &config.namespace {
                 quote_in! { file =>
-                    namespace #namespace {
-                        #tokens
+                    namespace $namespace {
+                        $tokens
                     }
                 }
 
@@ -198,7 +198,7 @@ impl Csharp {
             }
 
             if !imported.contains(namespace) {
-                quote_in!(*out => using #namespace;);
+                quote_in!(*out => using $namespace;);
                 out.push();
                 imported.insert(namespace);
             }
@@ -223,9 +223,9 @@ impl Csharp {
 /// let ob = csharp::import("Foo.Baz", "B");
 ///
 /// let toks: Tokens<Csharp> = quote! {
-///     #a
-///     #b
-///     #ob
+///     $a
+///     $b
+///     $ob
 /// };
 ///
 /// assert_eq!(
@@ -263,9 +263,9 @@ where
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(csharp::block_comment(vec!["Foo"]))
-///     #(csharp::block_comment(iter::empty::<&str>()))
-///     #(csharp::block_comment(vec!["Bar"]))
+///     $(csharp::block_comment(vec!["Foo"]))
+///     $(csharp::block_comment(iter::empty::<&str>()))
+///     $(csharp::block_comment(vec!["Bar"]))
 /// };
 ///
 /// assert_eq!(
@@ -295,8 +295,8 @@ where
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(csharp::comment(&["Foo"]))
-///     #(csharp::comment(&["Bar"]))
+///     $(csharp::comment(&["Foo"]))
+///     $(csharp::comment(&["Bar"]))
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/dart/mod.rs
+++ b/src/lang/dart/mod.rs
@@ -24,10 +24,10 @@
 //! use genco::prelude::*;
 //!
 //! # fn main() -> genco::fmt::Result {
-//! let toks: dart::Tokens = quote!(#_(  Hello: $var  ));
+//! let toks: dart::Tokens = quote!($[str](  Hello: $var  ));
 //! assert_eq!("\"  Hello: $var  \"", toks.to_string()?);
 //!
-//! let toks: dart::Tokens = quote!(#_(  Hello: $(a + b)  ));
+//! let toks: dart::Tokens = quote!($[str](  Hello: $(a + b)  ));
 //! assert_eq!("\"  Hello: ${a + b}  \"", toks.to_string()?);
 //! # Ok(())
 //! # }
@@ -206,9 +206,9 @@ impl Dart {
 
         for (name, alias) in modules {
             if let Some(alias) = alias {
-                quote_in!(*out => import #(quoted(name)) as #alias;);
+                quote_in!(*out => import $(quoted(name)) as $alias;);
             } else {
-                quote_in!(*out => import #(quoted(name)););
+                quote_in!(*out => import $(quoted(name)););
             }
 
             out.push();
@@ -232,10 +232,10 @@ impl Dart {
 /// let d = dart::import("../http.dart", "D");
 ///
 /// let toks = quote! {
-///     #a
-///     #b
-///     #c
-///     #d
+///     $a
+///     $b
+///     $c
+///     $d
 /// };
 ///
 /// let expected = vec![
@@ -275,9 +275,9 @@ where
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(dart::doc_comment(vec!["Foo"]))
-///     #(dart::doc_comment(iter::empty::<&str>()))
-///     #(dart::doc_comment(vec!["Bar"]))
+///     $(dart::doc_comment(vec!["Foo"]))
+///     $(dart::doc_comment(iter::empty::<&str>()))
+///     $(dart::doc_comment(vec!["Bar"]))
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/go.rs
+++ b/src/lang/go.rs
@@ -75,7 +75,7 @@ impl_lang! {
             let mut header = Tokens::new();
 
             if let Some(package) = &config.package {
-                quote_in!(header => package #package);
+                quote_in!(header => package $package);
                 header.line();
             }
 
@@ -143,7 +143,7 @@ impl Go {
         }
 
         for module in modules {
-            quote_in!(*out => import #(quoted(module)));
+            quote_in!(*out => import $(quoted(module)));
             out.push();
         }
 
@@ -162,7 +162,7 @@ impl Go {
 /// let ty = go::import("foo/bar", "Debug");
 ///
 /// let toks = quote! {
-///     #ty
+///     $ty
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/java/mod.rs
+++ b/src/lang/java/mod.rs
@@ -71,7 +71,7 @@ impl_lang! {
             let mut header = Tokens::new();
 
             if let Some(ref package) = config.package {
-                quote_in!(header => package #package;);
+                quote_in!(header => package $package;);
                 header.line();
             }
 
@@ -129,7 +129,7 @@ impl Config {
     /// # fn main() -> genco::fmt::Result {
     /// let optional = java::import("java.util", "Optional");
     ///
-    /// let toks = quote!(#optional);
+    /// let toks = quote!($optional);
     ///
     /// let config = java::Config::default().with_package("java.util");
     /// let fmt = fmt::Config::from_lang::<Java>();
@@ -202,7 +202,7 @@ impl Java {
                 continue;
             }
 
-            out.append(quote!(import #(package.clone())#(SEP)#(name.clone());));
+            out.append(quote!(import $(package.clone())$(SEP)$(name.clone());));
             out.push();
 
             imported.insert(name.to_string(), package.to_string());
@@ -224,8 +224,8 @@ impl Java {
 /// let a = java::import("java.io", "A");
 ///
 /// let toks = quote! {
-///     #integer
-///     #a
+///     $integer
+///     $a
 /// };
 ///
 /// assert_eq!(
@@ -261,9 +261,9 @@ where
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(java::block_comment(vec!["first line", "second line"]))
-///     #(java::block_comment(iter::empty::<&str>()))
-///     #(java::block_comment(vec!["third line"]))
+///     $(java::block_comment(vec!["first line", "second line"]))
+///     $(java::block_comment(iter::empty::<&str>()))
+///     $(java::block_comment(vec!["third line"]))
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/js.rs
+++ b/src/lang/js.rs
@@ -43,7 +43,7 @@
 //! let toks: js::Tokens = quote!("start π 😊 \n \x7f ÿ $ \\ end");
 //! assert_eq!("\"start π 😊 \\n \\x7f ÿ $ \\\\ end\"", toks.to_string()?);
 //!
-//! let toks: js::Tokens = quote!(#(quoted("start π 😊 \n \x7f ÿ $ \\ end")));
+//! let toks: js::Tokens = quote!($(quoted("start π 😊 \n \x7f ÿ $ \\ end")));
 //! assert_eq!("\"start π 😊 \\n \\x7f ÿ $ \\\\ end\"", toks.to_string()?);
 //! # Ok(())
 //! # }
@@ -213,9 +213,9 @@ impl Config {
     /// let react = js::import("react", "React").into_default();
     ///
     /// let toks: js::Tokens = quote! {
-    ///     #foo1
-    ///     #foo2
-    ///     #react
+    ///     $foo1
+    ///     $foo2
+    ///     $react
     /// };
     ///
     /// let mut w = fmt::VecWriter::new();
@@ -299,8 +299,8 @@ impl Import {
     /// let b = js::import("collections", "vec").with_alias("list");
     ///
     /// let toks = quote! {
-    ///     #a
-    ///     #b
+    ///     $a
+    ///     $b
     /// };
     ///
     /// assert_eq!(
@@ -336,7 +336,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let default_vec = js::import("collections", "defaultVec").into_default();
     ///
-    /// let toks = quote!(#default_vec);
+    /// let toks = quote!($default_vec);
     ///
     /// assert_eq!(
     ///     vec![
@@ -367,7 +367,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let all = js::import("collections", "all").into_wildcard();
     ///
-    /// let toks = quote!(#all);
+    /// let toks = quote!($all);
     ///
     /// assert_eq!(
     ///     vec![
@@ -455,14 +455,14 @@ impl JavaScript {
         for (module, name) in wildcards {
             out.push();
             quote_in! { *out =>
-                import * as #name from #(ref t => render_from(t, config.module_path.as_deref(), module));
+                import * as $name from $(ref t => render_from(t, config.module_path.as_deref(), module));
             }
         }
 
         for (name, module) in modules {
             out.push();
             quote_in! { *out =>
-                import #(ref tokens => {
+                import $(ref tokens => {
                     if let Some(default) = module.default_import {
                         tokens.append(ItemStr::from(default));
 
@@ -483,7 +483,7 @@ impl JavaScript {
                                     tokens.append(name);
                                 },
                                 ImportedElement::Aliased(name, alias) => {
-                                    quote_in!(*tokens => #name as #alias);
+                                    quote_in!(*tokens => $name as $alias);
                                 }
                             }
 
@@ -495,7 +495,7 @@ impl JavaScript {
 
                         tokens.append("}");
                     }
-                }) from #(ref t => render_from(t, config.module_path.as_deref(), name));
+                }) from $(ref t => render_from(t, config.module_path.as_deref(), name));
             };
         }
 
@@ -515,10 +515,10 @@ impl JavaScript {
 
         fn render_from(t: &mut js::Tokens, module_path: Option<&RelativePath>, module: &Module) {
             quote_in! { *t =>
-                #(match (module_path, module) {
-                    (_, Module::Global(from)) => #(quoted(from)),
-                    (None, Module::Path(path)) => #(quoted(path.as_str())),
-                    (Some(module_path), Module::Path(path)) => #(quoted(module_path.relative(path).as_str())),
+                $(match (module_path, module) {
+                    (_, Module::Global(from)) => $(quoted(from)),
+                    (None, Module::Path(path)) => $(quoted(path.as_str())),
+                    (Some(module_path), Module::Path(path)) => $(quoted(module_path.relative(path).as_str())),
                 })
             }
         }
@@ -539,10 +539,10 @@ impl JavaScript {
 /// let vec_as_list = js::import("collections", "vec").with_alias("list");
 ///
 /// let toks = quote! {
-///     #default_vec
-///     #all
-///     #vec
-///     #vec_as_list
+///     $default_vec
+///     $all
+///     $vec
+///     $vec_as_list
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -11,7 +11,7 @@
 //! let toks: python::Tokens = quote!("hello \n world");
 //! assert_eq!("\"hello \\n world\"", toks.to_string()?);
 //!
-//! let toks: python::Tokens = quote!(#(quoted("hello \n world")));
+//! let toks: python::Tokens = quote!($(quoted("hello \n world")));
 //! assert_eq!("\"hello \\n world\"", toks.to_string()?);
 //! # Ok(())
 //! # }
@@ -155,7 +155,7 @@ impl Import {
     ///
     /// # fn main() -> genco::fmt::Result {
     /// let toks = quote! {
-    ///     #(python::import("collections", "namedtuple").with_alias("nt"))
+    ///     $(python::import("collections", "namedtuple").with_alias("nt"))
     /// };
     ///
     /// assert_eq!(
@@ -188,7 +188,7 @@ impl Import {
     ///
     /// # fn main() -> genco::fmt::Result {
     /// let toks = quote! {
-    ///     #(python::import("collections", "namedtuple").qualified())
+    ///     $(python::import("collections", "namedtuple").qualified())
     /// };
     ///
     /// assert_eq!(
@@ -220,7 +220,7 @@ impl Import {
     ///
     /// # fn main() -> genco::fmt::Result {
     /// let toks = quote! {
-    ///     #(python::import("collections", "namedtuple").with_module_alias("c"))
+    ///     $(python::import("collections", "namedtuple").with_module_alias("c"))
     /// };
     ///
     /// assert_eq!(
@@ -267,7 +267,7 @@ impl ImportModule {
     ///
     /// # fn main() -> genco::fmt::Result {
     /// let toks = quote! {
-    ///     #(python::import_module("collections").with_alias("c"))
+    ///     $(python::import_module("collections").with_alias("c"))
     /// };
     ///
     /// assert_eq!(
@@ -329,16 +329,16 @@ impl Python {
 
             let imports = imports
                 .into_iter()
-                .map(|(name, alias)| quote!(#name#(if let Some(a) = alias => #<space>as #a)))
+                .map(|(name, alias)| quote!($name$(if let Some(a) = alias => $[' ']as $a)))
                 .collect::<Vec<_>>();
 
             if imports.len() == 1 {
                 quote_in! {*out =>
-                    from #module import #(imports.into_iter().next())
+                    from $module import $(imports.into_iter().next())
                 }
             } else {
                 quote_in! {*out =>
-                    from #module import #(for i in imports join (, ) => #i)
+                    from $module import $(for i in imports join (, ) => $i)
                 }
             }
         }
@@ -347,7 +347,7 @@ impl Python {
             out.push();
 
             quote_in! {*out =>
-                import #module#(if let Some(a) = alias => #<space>as #a)
+                import $module$(if let Some(a) = alias => $[' ']as $a)
             }
         }
 
@@ -364,10 +364,10 @@ impl Python {
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(python::import("collections", "namedtuple").with_alias("nt"))
-///     #(python::import("collections", "namedtuple"))
-///     #(python::import("collections", "namedtuple").qualified())
-///     #(python::import("collections", "namedtuple").with_module_alias("c"))
+///     $(python::import("collections", "namedtuple").with_alias("nt"))
+///     $(python::import("collections", "namedtuple"))
+///     $(python::import("collections", "namedtuple").qualified())
+///     $(python::import("collections", "namedtuple").with_module_alias("c"))
 /// };
 ///
 /// assert_eq!(
@@ -409,8 +409,8 @@ where
 ///
 /// # fn main() -> genco::fmt::Result {
 /// let toks = quote! {
-///     #(python::import_module("collections"))
-///     #(python::import_module("collections").with_alias("c"))
+///     $(python::import_module("collections"))
+///     $(python::import_module("collections").with_alias("c"))
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/rust.rs
+++ b/src/lang/rust.rs
@@ -269,7 +269,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let ty = rust::import("std::fmt", "Debug").with_alias("FmtDebug");
     ///
-    /// let toks = quote!(#ty);
+    /// let toks = quote!($ty);
     ///
     /// assert_eq!(
     ///     vec![
@@ -302,7 +302,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let ty = rust::import("std::fmt", "Debug").with_module_alias("other");
     ///
-    /// let toks = quote!(#ty);
+    /// let toks = quote!($ty);
     ///
     /// assert_eq!(
     ///     vec![
@@ -341,7 +341,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let ty = rust::import("std::fmt", "Debug").qualified();
     ///
-    /// let toks = quote!(#ty);
+    /// let toks = quote!($ty);
     ///
     /// assert_eq!(
     ///     vec![
@@ -373,7 +373,7 @@ impl Import {
     /// # fn main() -> genco::fmt::Result {
     /// let ty = rust::import("std::fmt", "Debug").direct();
     ///
-    /// let toks = quote!(#ty);
+    /// let toks = quote!($ty);
     ///
     /// assert_eq!(
     ///     vec![
@@ -477,31 +477,31 @@ impl Rust {
                 // imported.
                 if let Some(second) = render.next() {
                     quote_in! { *out =>
-                        use #m::{#(ref o =>
+                        use $m::{$(ref o =>
                             first.render(o);
-                            quote_in!(*o => , #(ref o => second.render(o)));
+                            quote_in!(*o => , $(ref o => second.render(o)));
 
                             for item in render {
-                                quote_in!(*o => , #(ref o => item.render(o)));
+                                quote_in!(*o => , $(ref o => item.render(o)));
                             }
                         )};
                     };
                 } else {
                     match first {
                         RenderItem::SelfImport => {
-                            quote_in!(*out => use #m;);
+                            quote_in!(*out => use $m;);
                         }
                         RenderItem::SelfAlias { alias } => {
-                            quote_in!(*out => use #m as #alias;);
+                            quote_in!(*out => use $m as $alias;);
                         }
                         RenderItem::Name {
                             name,
                             alias: Some(alias),
                         } => {
-                            quote_in!(*out => use #m::#name as #alias;);
+                            quote_in!(*out => use $m::$name as $alias;);
                         }
                         RenderItem::Name { name, alias: None } => {
-                            quote_in!(*out => use #m::#name;);
+                            quote_in!(*out => use $m::$name;);
                         }
                     }
                 }
@@ -585,16 +585,16 @@ impl Rust {
                         quote_in!(*out => self);
                     }
                     Self::SelfAlias { alias } => {
-                        quote_in!(*out => self as #alias);
+                        quote_in!(*out => self as $alias);
                     }
                     Self::Name {
                         name,
                         alias: Some(alias),
                     } => {
-                        quote_in!(*out => #name as #alias);
+                        quote_in!(*out => $name as $alias);
                     }
                     Self::Name { name, alias: None } => {
-                        quote_in!(*out => #name);
+                        quote_in!(*out => $name);
                     }
                 }
             }
@@ -616,10 +616,10 @@ impl Rust {
 /// let d = rust::import("std::fmt", "Debug").with_alias("FmtDebug");
 ///
 /// let toks = quote!{
-///     #a
-///     #b
-///     #c
-///     #d
+///     $a
+///     $b
+///     $c
+///     $d
 /// };
 ///
 /// assert_eq!(
@@ -646,7 +646,7 @@ impl Rust {
 /// let ty = rust::import("std::fmt", "Debug").with_alias("FmtDebug");
 ///
 /// let toks = quote!{
-///     #ty
+///     $ty
 /// };
 ///
 /// assert_eq!(
@@ -670,7 +670,7 @@ impl Rust {
 /// let ty = rust::import("std::fmt", "Debug").with_module_alias("fmt2");
 ///
 /// let toks = quote!{
-///     #ty
+///     $ty
 /// };
 ///
 /// assert_eq!(
@@ -695,8 +695,8 @@ impl Rust {
 /// let b = rust::import("std::fmt", "Debug").with_alias("FmtDebug2");
 ///
 /// let toks = quote!{
-///     #a
-///     #b
+///     $a
+///     $b
 /// };
 ///
 /// assert_eq!(

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -104,7 +104,7 @@ impl Swift {
 
         if !modules.is_empty() {
             for module in modules {
-                quote_in! { *out => #<push>import #module}
+                quote_in! { *out => $['\r']import $module}
             }
         }
 
@@ -120,7 +120,7 @@ impl Swift {
 /// use genco::prelude::*;
 ///
 /// # fn main() -> genco::fmt::Result {
-/// let toks = quote!(#(swift::import("Foo", "Debug")));
+/// let toks = quote!($(swift::import("Foo", "Debug")));
 ///
 /// assert_eq!(
 ///     vec![

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,11 +42,11 @@
 ///                 match import {
 ///                     Any::Import(import) => {
 ///                         header.push();
-///                         quote_in!(header => import #(import.0));
+///                         quote_in!(header => import $(import.0));
 ///                     }
 ///                     Any::ImportDefault(import) => {
 ///                         header.push();
-///                         quote_in!(header => import default #(import.0));
+///                         quote_in!(header => import default $(import.0));
 ///                     }
 ///                 }
 ///             }
@@ -91,8 +91,8 @@
 /// let b = ImportDefault("second");
 ///
 /// let t: Tokens<MyLang> = quote! {
-///     #a
-///     #b
+///     $a
+///     $b
 /// };
 ///
 /// assert_eq! {

--- a/src/tokens/display.rs
+++ b/src/tokens/display.rs
@@ -37,8 +37,8 @@ use std::fmt;
 /// let foo = Foo(());
 ///
 /// let tokens = quote! {
-///     let mut m = #map::<u32, &str>::new();
-///     m.insert(0, #(display(&foo)));
+///     let mut m = $map::<u32, &str>::new();
+///     m.insert(0, $(display(&foo)));
 /// };
 ///
 /// assert_eq!(

--- a/src/tokens/format_into.rs
+++ b/src/tokens/format_into.rs
@@ -29,7 +29,7 @@ use std::rc::Rc;
 /// {
 ///     from_fn(move |tokens| {
 ///         let s = s.into();
-///         quote_in!(*tokens => #(static_literal("//")) #s);
+///         quote_in!(*tokens => $(static_literal("//")) $s);
 ///     })
 /// }
 /// # Ok(())
@@ -68,7 +68,7 @@ where
 /// # fn main() -> genco::fmt::Result {
 /// let a: &Tokens = &quote!(foo bar);
 ///
-/// let result = quote!(#a baz);
+/// let result = quote!($a baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -94,9 +94,9 @@ where
 /// # fn main() -> genco::fmt::Result {
 /// let mut vec = Vec::<Tokens>::new();
 /// vec.push(quote!(foo));
-/// vec.push(quote!(#<space>bar));
+/// vec.push(quote!($[' ']bar));
 ///
-/// let result = quote!(#vec baz);
+/// let result = quote!($vec baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -128,7 +128,7 @@ where
 /// let vec = vec!["foo", " ", "bar"];
 /// let slice = &vec[..];
 ///
-/// let result: Tokens = quote!(#slice baz);
+/// let result: Tokens = quote!($slice baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -157,7 +157,7 @@ where
 /// let foo = "foo";
 /// let bar = "bar";
 ///
-/// let result: Tokens = quote!(#foo #bar baz);
+/// let result: Tokens = quote!($foo $bar baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -183,7 +183,7 @@ where
 /// let foo = String::from("foo");
 /// let bar = String::from("bar");
 ///
-/// let result: Tokens = quote!(#(&foo) #(&bar) baz);
+/// let result: Tokens = quote!($(&foo) $(&bar) baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -210,7 +210,7 @@ where
 /// let foo = String::from("foo");
 /// let bar = String::from("bar");
 ///
-/// let result: Tokens = quote!(#foo #bar baz);
+/// let result: Tokens = quote!($foo $bar baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -237,7 +237,7 @@ where
 /// let foo = Rc::new(String::from("foo"));
 /// let bar = Rc::new(String::from("bar"));
 ///
-/// let result: Tokens = quote!(#foo #bar baz);
+/// let result: Tokens = quote!($foo $bar baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -265,7 +265,7 @@ where
 /// let foo = Rc::new(String::from("foo"));
 /// let bar = Rc::new(String::from("bar"));
 ///
-/// let result: Tokens = quote!(#(&foo) #(&bar) baz);
+/// let result: Tokens = quote!($(&foo) $(&bar) baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())
@@ -289,7 +289,7 @@ where
 /// use genco::prelude::*;
 ///
 /// let name = "John";
-/// let result: Tokens = quote!(#(format_args!("Hello {name}")));
+/// let result: Tokens = quote!($(format_args!("Hello {name}")));
 ///
 /// assert_eq!("Hello John", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
@@ -316,7 +316,7 @@ where
 /// let bar = Some("bar");
 /// let biz = None::<&str>;
 ///
-/// let result: Tokens = quote!(#foo #bar baz #biz);
+/// let result: Tokens = quote!($foo $bar baz $biz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok(())

--- a/src/tokens/from_fn.rs
+++ b/src/tokens/from_fn.rs
@@ -18,7 +18,7 @@ use crate::Tokens;
 /// {
 ///     from_fn(move |tokens| {
 ///         let s = s.into();
-///         quote_in!(*tokens => #(static_literal("//")) #s);
+///         quote_in!(*tokens => $(static_literal("//")) #s);
 ///     })
 /// }
 /// # Ok(())

--- a/src/tokens/item.rs
+++ b/src/tokens/item.rs
@@ -59,7 +59,7 @@ where
 /// let foo = Item::Literal(ItemStr::Static("foo"));
 /// let bar = Item::Literal(ItemStr::Box("bar".into()));
 ///
-/// let result: Tokens = quote!(#foo #bar baz);
+/// let result: Tokens = quote!($foo $bar baz);
 ///
 /// assert_eq!("foo bar baz", result.to_string()?);
 ///

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -22,11 +22,11 @@
 //!
 //!         if it.peek().is_some() {
 //!             quote_in! { *t =>
-//!                 #(static_literal("/**"))
-//!                 #(for line in it join (#<push>) {
-//!                     #<space>* #(line.into())
+//!                 $(static_literal("/**"))
+//!                 $(for line in it join ($['\r']) {
+//!                     $[' ']* $(line.into())
 //!                 })
-//!                 #<space>#(static_literal("*/"))
+//!                 $[' ']$(static_literal("*/"))
 //!             }
 //!         }
 //!     })
@@ -36,7 +36,7 @@
 //! use genco::prelude::*;
 //!
 //! let tokens: java::Tokens = quote! {
-//!     #(block_comment(&["This class is used for awesome stuff", "ok?"]))
+//!     $(block_comment(&["This class is used for awesome stuff", "ok?"]))
 //!     public static class Foo {
 //!     }
 //! };

--- a/src/tokens/quoted.rs
+++ b/src/tokens/quoted.rs
@@ -19,8 +19,8 @@ use crate::tokens::{FormatInto, Item, Tokens};
 /// let map = rust::import("std::collections", "HashMap");
 ///
 /// let tokens = quote! {
-///     let mut m = #map::<u32, &str>::new();
-///     m.insert(0, #(quoted("hello\" world")));
+///     let mut m = $map::<u32, &str>::new();
+///     m.insert(0, $(quoted("hello\" world")));
 /// };
 ///
 /// assert_eq!(
@@ -44,7 +44,7 @@ use crate::tokens::{FormatInto, Item, Tokens};
 /// use genco::prelude::*;
 ///
 /// # fn main() -> genco::fmt::Result {
-/// let tokens: python::Tokens = quote!(#_(Hello #(quoted("World 😊"))));
+/// let tokens: python::Tokens = quote!($[str](Hello $[const](quoted("World 😊"))));
 ///
 /// assert_eq!(
 ///     "\"Hello \\\"World \\U0001f60a\\\"\"",

--- a/src/tokens/register.rs
+++ b/src/tokens/register.rs
@@ -16,16 +16,16 @@ use crate::Tokens;
 /// let big_endian = &rust::import("byteorder", "BigEndian");
 ///
 /// let tokens = quote! {
-///     #(register((write_bytes_ext, read_bytes_ext)))
+///     $(register((write_bytes_ext, read_bytes_ext)))
 ///
 ///     let mut wtr = vec![];
-///     wtr.write_u16::<#big_endian>(517).unwrap();
-///     wtr.write_u16::<#big_endian>(768).unwrap();
+///     wtr.write_u16::<$big_endian>(517).unwrap();
+///     wtr.write_u16::<$big_endian>(768).unwrap();
 ///     assert_eq!(wtr, vec![2, 5, 3, 0]);
 ///
-///     let mut rdr = #cursor::new(vec![2, 5, 3, 0]);
-///     assert_eq!(517, rdr.read_u16::<#big_endian>().unwrap());
-///     assert_eq!(768, rdr.read_u16::<#big_endian>().unwrap());
+///     let mut rdr = $cursor::new(vec![2, 5, 3, 0]);
+///     assert_eq!(517, rdr.read_u16::<$big_endian>().unwrap());
+///     assert_eq!(768, rdr.read_u16::<$big_endian>().unwrap());
 /// };
 ///
 /// assert_eq!(

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -25,11 +25,11 @@ use std::vec;
 ///
 /// This stream of tokens provides the following structural guarantees.
 ///
-/// * Only one [space] may occur in sequence.
-/// * Only one [push] may occur in sequence.
-/// * A [push] may never be preceeded by a [line], since it would have no
+/// * Only one [' '] may occur in sequence.
+/// * Only one ['\r'] may occur in sequence.
+/// * A ['\r'] may never be preceeded by a ['\n'], since it would have no
 ///   effect.
-/// * Every [line] must be preceeded by a [push].
+/// * Every ['\n'] must be preceeded by a ['\r'].
 ///
 /// ```rust
 /// use genco::Tokens;
@@ -43,9 +43,9 @@ use std::vec;
 /// assert_eq!(vec![Item::Push::<()>], tokens);
 /// ```
 ///
-/// [space]: Self::space()
-/// [push]: Self::push()
-/// [line]: Self::line()
+/// [' ']: Self::space()
+/// ['\r']: Self::push()
+/// ['\n']: Self::line()
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Tokens<L = ()>
 where
@@ -146,7 +146,7 @@ where
     /// let mut tokens = Tokens::<()>::new();
     /// tokens.append(4u32);
     ///
-    /// assert_eq!(quote!(#(4u32)), tokens);
+    /// assert_eq!(quote!($(4u32)), tokens);
     /// ```
     pub fn append<T>(&mut self, tokens: T)
     where
@@ -158,11 +158,11 @@ where
     /// Extend with another stream of tokens.
     ///
     /// This respects the structural requirements of adding one element at a
-    /// time, like you would get by calling [space], [push], or [line].
+    /// time, like you would get by calling [' '], ['\r'], or ['\n'].
     ///
-    /// [space]: Self::space()
-    /// [push]: Self::push()
-    /// [line]: Self::line()
+    /// [' ']: Self::space()
+    /// ['\r']: Self::push()
+    /// ['\n']: Self::line()
     ///
     /// # Examples
     ///
@@ -171,7 +171,7 @@ where
     /// use genco::tokens::{Item, ItemStr};
     ///
     /// let mut tokens: Tokens<()> = quote!(foo bar);
-    /// tokens.extend::<Tokens<()>>(quote!(#<space>baz));
+    /// tokens.extend::<Tokens<()>>(quote!($[' ']baz));
     ///
     /// assert_eq!(tokens, quote!(foo bar baz));
     /// ```
@@ -201,7 +201,7 @@ where
     /// let debug = rust::import("std::fmt", "Debug");
     /// let ty = rust::import("std::collections", "HashMap");
     ///
-    /// let tokens = quote!(foo #ty<u32, dyn #debug> baz);
+    /// let tokens = quote!(foo $ty<u32, dyn $debug> baz);
     ///
     /// for import in tokens.walk_imports() {
     ///     println!("{:?}", import);
@@ -227,7 +227,7 @@ where
     /// # fn main() -> genco::fmt::Result {
     /// let write_bytes_ext = rust::import("byteorder", "WriteBytesExt").with_alias("_");
     ///
-    /// let tokens = quote!(#(register(write_bytes_ext)));
+    /// let tokens = quote!($(register(write_bytes_ext)));
     ///
     /// assert_eq!("use byteorder::WriteBytesExt as _;\n", tokens.to_file_string()?);
     /// # Ok(())
@@ -395,10 +395,10 @@ where
     /// the beginning of a line preceeding any non-whitespace tokens.
     ///
     /// An indentation has no effect unless it's *followed* by non-whitespace
-    /// tokens. It also acts like a [push], in that it will shift any tokens to
+    /// tokens. It also acts like a ['\r'], in that it will shift any tokens to
     /// a new line.
     ///
-    /// [push]: Self::push
+    /// ['\r']: Self::push
     ///
     /// # Examples
     ///
@@ -436,7 +436,7 @@ where
     /// the beginning of a line preceeding any non-whitespace tokens.
     ///
     /// An indentation has no effect unless it's *followed* by non-whitespace
-    /// tokens. It also acts like a [push], in that it will shift any tokens to
+    /// tokens. It also acts like a ['\r'], in that it will shift any tokens to
     /// a new line.
     ///
     /// Indentation can never go below zero, and will just be ignored if that
@@ -444,7 +444,7 @@ where
     /// stream, so any negative indentation in place will have to be countered
     /// before indentation starts again.
     ///
-    /// [push]: Self::push
+    /// ['\r']: Self::push
     ///
     /// # Examples
     ///
@@ -512,7 +512,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -612,7 +612,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -697,7 +697,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -734,7 +734,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -772,7 +772,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -842,7 +842,7 @@ where
     /// let map = rust::import("std::collections", "HashMap");
     ///
     /// let tokens: rust::Tokens = quote! {
-    ///     let mut m = #map::new();
+    ///     let mut m = $map::new();
     ///     m.insert(1u32, 2u32);
     /// };
     ///
@@ -1089,10 +1089,10 @@ mod tests {
     #[test]
     fn test_walk_custom() {
         let toks: Tokens<Lang> = quote! {
-            1:1 #(Import(1)) 1:2
+            1:1 $(Import(1)) 1:2
             bar
-            2:1 2:2 #(quote!(3:1 3:2)) #(Import(2))
-            #(String::from("nope"))
+            2:1 2:2 $(quote!(3:1 3:2)) $(Import(2))
+            $(String::from("nope"))
         };
 
         let mut output: Vec<_> = toks.walk_imports().cloned().collect();

--- a/tests/test_option.rs
+++ b/tests/test_option.rs
@@ -2,13 +2,13 @@ use genco::prelude::*;
 
 #[test]
 fn test_option() -> genco::fmt::Result {
-    let test1 = Some(quote!(println!("{}", #(quoted("one")))));
+    let test1 = Some(quote!(println!("{}", $(quoted("one")))));
     let test2 = None::<rust::Tokens>;
 
     let tokens: rust::Tokens = quote! {
         fn test_option() -> u32 {
-            #test1
-            #test2
+            $test1
+            $test2
 
             42
         }

--- a/tests/test_quote.rs
+++ b/tests/test_quote.rs
@@ -6,7 +6,7 @@ fn test_quote() -> genco::fmt::Result {
 
     let tokens: rust::Tokens = quote! {
         fn test() -> u32 {
-            println!("{}", #(test));
+            println!("{}", $(test));
 
             42
         }
@@ -19,7 +19,7 @@ fn test_quote() -> genco::fmt::Result {
 
     let tokens: rust::Tokens = quote! {
         fn test() -> u32 {
-            println!("{}", #(quoted("two")));
+            println!("{}", $(quoted("two")));
 
             42
         }
@@ -32,14 +32,14 @@ fn test_quote() -> genco::fmt::Result {
 
     let tokens: rust::Tokens = quote! {
         fn test() -> u32 {
-            println!("{}", ##(quoted("two")));
+            println!("{}", $$(quoted("two")));
 
             42
         }
     };
 
     assert_eq!(
-        "fn test() -> u32 {\n    println!(\"{}\", #(quoted(\"two\")));\n\n    42\n}",
+        "fn test() -> u32 {\n    println!(\"{}\", $(quoted(\"two\")));\n\n    42\n}",
         tokens.to_string()?
     );
 
@@ -51,7 +51,7 @@ fn test_tight_quote() -> genco::fmt::Result {
     let foo = "foo";
     let bar = "bar";
     let baz = "baz";
-    let tokens: rust::Tokens = quote!(#(foo)#(bar)#(baz));
+    let tokens: rust::Tokens = quote!($(foo)$(bar)$(baz));
 
     assert_eq!("foobarbaz", tokens.to_string()?);
 
@@ -60,8 +60,8 @@ fn test_tight_quote() -> genco::fmt::Result {
 
 #[test]
 fn test_escape() -> genco::fmt::Result {
-    let tokens: rust::Tokens = quote!(#### ## #### #### ## ## ##[test]);
-    assert_eq!("## # ## ## # # #[test]", tokens.to_string()?);
+    let tokens: rust::Tokens = quote!($$$$ $$ $$$$ $$$$ $$ $$ $$[test]);
+    assert_eq!("$$ $ $$ $$ $ $ $[test]", tokens.to_string()?);
 
     Ok(())
 }
@@ -70,7 +70,7 @@ fn test_escape() -> genco::fmt::Result {
 fn test_scope() -> genco::fmt::Result {
     let tokens: rust::Tokens = quote! {
         // Nested factory.
-        #(ref tokens {
+        $(ref tokens {
             quote_in!(*tokens => fn test() -> u32 { 42 });
         })
     };

--- a/tests/test_quote_simple_expression.rs
+++ b/tests/test_quote_simple_expression.rs
@@ -2,18 +2,18 @@ use genco::prelude::*;
 
 #[test]
 fn test_quote_simple_expression() -> genco::fmt::Result {
-    let tokens: Tokens<Rust> = quote!(fn #("test")());
+    let tokens: Tokens<Rust> = quote!(fn $("test")());
     assert_eq!("fn test()", tokens.to_string()?);
 
     let expr = &quote!(test);
-    let tokens: Tokens<Rust> = quote!(fn #expr());
+    let tokens: Tokens<Rust> = quote!(fn $expr());
     assert_eq!("fn test()", tokens.to_string()?);
 
-    let tokens: Tokens<Rust> = quote!(fn #(expr)());
+    let tokens: Tokens<Rust> = quote!(fn $(expr)());
     assert_eq!("fn test()", tokens.to_string()?);
 
     // inline macro expansion.
-    let tokens: Tokens<Rust> = quote!(fn #(quote!(test))());
+    let tokens: Tokens<Rust> = quote!(fn $(quote!(test))());
     assert_eq!("fn test()", tokens.to_string()?);
 
     Ok(())

--- a/tests/test_register.rs
+++ b/tests/test_register.rs
@@ -5,7 +5,7 @@ fn test_register() -> genco::fmt::Result {
     let import = rust::import("std::iter", "FromIterator").with_alias("_");
 
     let tokens: Tokens<Rust> = quote! {
-        #(register(import))
+        $(register(import))
         // additional lines are ignored!
 
         fn test() -> u32 {

--- a/tests/test_string.rs
+++ b/tests/test_string.rs
@@ -2,26 +2,26 @@ use genco::prelude::*;
 
 #[test]
 fn test_quoted() -> genco::fmt::Result {
-    let t: dart::Tokens = quote!(#_(Hello $(#(quoted("World")))));
+    let t: dart::Tokens = quote!($[str](Hello $($(quoted("World")))));
     assert_eq!("\"Hello ${\"World\"}\"", t.to_string()?);
 
-    let t: dart::Tokens = quote!(#_(Hello "World"));
+    let t: dart::Tokens = quote!($[str](Hello "World"));
     assert_eq!("\"Hello \\\"World\\\"\"", t.to_string()?);
 
-    let t: dart::Tokens = quote!(#_(Hello $(World)));
+    let t: dart::Tokens = quote!($[str](Hello $(World)));
     assert_eq!("\"Hello $World\"", t.to_string()?);
 
-    let t: js::Tokens = quote!(#_(Hello $(World)));
+    let t: js::Tokens = quote!($[str](Hello $(World)));
     assert_eq!("`Hello ${World}`", t.to_string()?);
     Ok(())
 }
 
 #[test]
 fn test_string_in_string_in() -> genco::fmt::Result {
-    let t: dart::Tokens = quote!(#_(Hello $(#_($(#_(World))))));
+    let t: dart::Tokens = quote!($[str](Hello $($[str]($($[str](World))))));
     assert_eq!("\"Hello ${\"${\"World\"}\"}\"", t.to_string()?);
 
-    let t: js::Tokens = quote!(#_(Hello $(#_($(#_(World))))));
+    let t: js::Tokens = quote!($[str](Hello $($[str]($($[str](World))))));
     assert_eq!("`Hello ${`${\"World\"}`}`", t.to_string()?);
     Ok(())
 }

--- a/tests/test_token_gen.rs
+++ b/tests/test_token_gen.rs
@@ -10,7 +10,7 @@ fn test_token_gen() {
         foo
         bar
         baz
-            #(ref tokens => quote_in! { *tokens => hello })
+            $(ref tokens => quote_in! { *tokens => hello })
         out?
     };
 
@@ -33,7 +33,7 @@ fn test_token_gen() {
 #[test]
 fn test_iterator_gen() {
     let tokens: rust::Tokens = quote! {
-        #(ref t => for n in 0..3 {
+        $(ref t => for n in 0..3 {
             t.push();
             t.append(n);
         })
@@ -52,7 +52,7 @@ fn test_iterator_gen() {
     };
 
     let tokens: rust::Tokens = quote! {
-        #(ref t {
+        $(ref t {
             for n in 0..3 {
                 t.push();
                 t.append(n);
@@ -81,7 +81,7 @@ fn test_tricky_continuation() {
 
     quote_in! {
         &mut output =>
-        foo, #(ref output {
+        foo, $(ref output {
             output.append(&bar);
             output.append(Static(","));
             output.space();
@@ -153,7 +153,7 @@ fn test_indentation() {
 #[test]
 fn test_repeat() {
     let tokens: rust::Tokens = quote! {
-        foo #(for (a, b) in (0..3).zip(3..6) => #a #b)
+        foo $(for (a, b) in (0..3).zip(3..6) => $a $b)
     };
 
     assert_eq! {
@@ -174,7 +174,7 @@ fn test_repeat() {
     };
 
     let tokens: rust::Tokens = quote! {
-        foo #(for (a, b) in (0..3).zip(3..6) { #a #b })
+        foo $(for (a, b) in (0..3).zip(3..6) { $a $b })
     };
 
     assert_eq! {
@@ -198,7 +198,7 @@ fn test_repeat() {
 #[test]
 fn test_tight_quote() {
     let output: rust::Tokens = quote! {
-        You are:#("fine")
+        You are:$("fine")
     };
 
     assert_eq! {
@@ -214,7 +214,7 @@ fn test_tight_quote() {
 #[test]
 fn test_tight_repitition() {
     let output: rust::Tokens = quote! {
-        You are: #(for v in 0..3 join (, ) => #v)
+        You are: $(for v in 0..3 join (, ) => $v)
     };
 
     assert_eq! {
@@ -241,13 +241,13 @@ fn test_if() {
     let b = false;
 
     let output: rust::Tokens = quote! {
-        #(if a => foo)
-        #(if a { foo2 })
-        #(if b { bar })
-        #(if b => bar2)
-        #(if a => baz)
-        #(if a { baz2 })
-        #(if b { not_biz } else { biz })
+        $(if a => foo)
+        $(if a { foo2 })
+        $(if b { bar })
+        $(if b => bar2)
+        $(if a => baz)
+        $(if a { baz2 })
+        $(if b { not_biz } else { biz })
     };
 
     assert_eq! {
@@ -275,19 +275,19 @@ fn test_match() {
 
     fn test(alt: Alt) -> rust::Tokens {
         quote! {
-            #(match alt { Alt::A => a, Alt::B => b })
+            $(match alt { Alt::A => a, Alt::B => b })
         }
     }
 
     fn test2(alt: Alt) -> rust::Tokens {
         quote! {
-            #(match alt { Alt::A => { a }, Alt::B => { b } })
+            $(match alt { Alt::A => { a }, Alt::B => { b } })
         }
     }
 
     fn test2_cond(alt: Alt, cond: bool) -> rust::Tokens {
         quote! {
-            #(match alt { Alt::A if cond => { a }, _ => { b } })
+            $(match alt { Alt::A if cond => { a }, _ => { b } })
         }
     }
 
@@ -327,7 +327,7 @@ fn test_empty_loop_whitespace() {
     // Bug: This should generate two commas. But did generate a space following
     // it!
     let tokens: rust::Tokens = quote! {
-        #(for _ in 0..3 join(,) =>)
+        $(for _ in 0..3 join(,) =>)
     };
 
     assert_eq! {
@@ -336,7 +336,7 @@ fn test_empty_loop_whitespace() {
     };
 
     let tokens: rust::Tokens = quote! {
-        #(for _ in 0..3 join( ,) =>)
+        $(for _ in 0..3 join( ,) =>)
     };
 
     assert_eq! {
@@ -345,7 +345,7 @@ fn test_empty_loop_whitespace() {
     };
 
     let tokens: rust::Tokens = quote! {
-          #(for _ in 0..3 join(, ) =>)
+          $(for _ in 0..3 join(, ) =>)
     };
 
     assert_eq! {
@@ -354,7 +354,7 @@ fn test_empty_loop_whitespace() {
     };
 
     let tokens: rust::Tokens = quote! {
-          #(for _ in 0..3 join( , ) =>)
+          $(for _ in 0..3 join( , ) =>)
     };
 
     assert_eq! {
@@ -367,7 +367,7 @@ fn test_empty_loop_whitespace() {
 fn test_indentation_empty() {
     let tokens: rust::Tokens = quote! {
         a
-            #(for _ in 0..3 =>)
+            $(for _ in 0..3 =>)
         b
     };
 
@@ -381,7 +381,7 @@ fn test_indentation_empty() {
 
     let tokens: rust::Tokens = quote! {
         a
-            #(if false {})
+            $(if false {})
         b
     };
 
@@ -395,7 +395,7 @@ fn test_indentation_empty() {
 
     let tokens: rust::Tokens = quote! {
         a
-            #(ref _tokens =>)
+            $(ref _tokens =>)
         b
     };
 
@@ -443,9 +443,9 @@ fn test_indentation_management() {
             if b:
                 foo
 
-        #(if false => bar)
+        $(if false => bar)
 
-        #(if true => baz)
+        $(if true => baz)
     };
 
     assert_eq! {
@@ -514,7 +514,7 @@ fn test_lines() -> fmt::Result {
     tokens.line();
 
     quote_in! { tokens =>
-        #(if false =>)
+        $(if false =>)
         fn bar() {
         }
     };


### PR DESCRIPTION
We have to stop using `#` as a delimiter, because the 2021 edition *reserved* any identifier-prefixed `#` tokens making expressions like these no longer be legal:

```rust
quote!(hello#world);
```

This would be seen as the `hello#world` token by Rust 2021, and since the `hello` prefix is not recognized by the Rust compiler and would not compile. See https://doc.rust-lang.org/edition-guide/rust-2021/reserving-syntax.html for more.

`$` does not suffer from this (and is more in the spirit of macros) so we're now moving all syntax to use it even if that means it's a bit more verbose.

This implements the following parser changes:
* `#var` is now `$var`.
* `#(var + 5)` is now `$(var + 5)`
* `#_(hello world)` is now `$[str](hello world)`.
* `#_(hello $world)` is now `$[str](hello $world)` (runtime evaluation, like having `hello ${world}` in javascript).
* `#_(hello $(world + 1))` is now `$[str](hello $(world + 1))` (runtime evaluation, like having `hello ${world + 1}` in javascript).
* `#_(hello #world)` is now `$[str](hello $[const](world))` (compile time evaluation, whatever value `world` has will become a component of the generated string).

The following control sequences are changed:
* `#<space>` becomes `$[' ']`
* `#<push>` becomes `$['\r']`.
* `#<line>` becomes `$['\n']`.

This change will be part of the `genco` 0.17 release.