### PR TITLE
Perform own detection for proc_macro_span (fixes #39)

### DIFF
--- a/examples/java_string.rs
+++ b/examples/java_string.rs
@@ -1,0 +1,7 @@
+use genco::prelude::*;
+
+fn main() -> Result<(), genco::fmt::Error> {
+    let tokens: python::Tokens = quote!($[str](Hello World));
+    assert_eq!("\"Hello World\"", tokens.to_string()?);
+    Ok::<_, genco::fmt::Error>(())
+}

--- a/genco-macros/build.rs
+++ b/genco-macros/build.rs
@@ -1,0 +1,35 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let version = rustc_version().unwrap_or(RustcVersion {
+        minor: u32::MAX,
+        nightly: false,
+    });
+
+    if version.nightly {
+        println!("cargo:rustc-cfg=proc_macro_span");
+    }
+}
+
+struct RustcVersion {
+    #[allow(unused)]
+    minor: u32,
+    nightly: bool,
+}
+
+fn rustc_version() -> Option<RustcVersion> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let nightly = version.contains("nightly") || version.contains("dev");
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    let minor = pieces.next()?.parse().ok()?;
+    Some(RustcVersion { minor, nightly })
+}

--- a/genco-macros/src/lib.rs
+++ b/genco-macros/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![recursion_limit = "256"]
 #![allow(clippy::type_complexity)]
+#![cfg_attr(proc_macro_span, feature(proc_macro_span))]
 
 extern crate proc_macro;
 

--- a/genco-macros/src/quote.rs
+++ b/genco-macros/src/quote.rs
@@ -348,7 +348,7 @@ impl<'a> Quote<'a> {
                         ));
                     }
                     (LiteralName::Ident("str"), Some(content)) => {
-                        let parser = StringParser::new(self.receiver, end);
+                        let parser = StringParser::new(self.receiver, &self.buf, end)?;
 
                         let (options, r, stream) = parser.parse(&content)?;
                         encoder.requirements.merge_with(r);


### PR DESCRIPTION
This implements a solution for #39 by performing the equivalent detection ourselves in a `build.rs` and implementing our own internal line column shim otherwise.