### PR TITLE
Fix build error "field, not a method" for line and column

### DIFF
--- a/genco-macros/src/fake.rs
+++ b/genco-macros/src/fake.rs
@@ -23,8 +23,8 @@ impl LineColumn {
         let span = span.unwrap().start();
 
         Some(Self {
-            line: span.line(),
-            column: span.column(),
+            line: span.line,
+            column: span.column,
         })
     }
 
@@ -33,8 +33,8 @@ impl LineColumn {
         let span = span.unwrap().end();
 
         Some(Self {
-            line: span.line(),
-            column: span.column(),
+            line: span.line,
+            column: span.column,
         })
     }
 


### PR DESCRIPTION
# Fix build

## Current behavior

Not sure how the CI could pass otherwise, just pulling the repo and running `cargo build` raises this error

```bash
$ cargo build --locked
   Compiling genco-macros v0.17.6 (/Users/clementwalter/Documents/genco/genco-macros)
error[E0599]: no method named `line` found for struct `proc_macro::LineColumn` in the current scope
  --> genco-macros/src/fake.rs:26:24
   |
26 |             line: span.line(),
   |                        ^^^^-- help: remove the arguments
   |                        |
   |                        field, not a method

error[E0599]: no method named `column` found for struct `proc_macro::LineColumn` in the current scope
  --> genco-macros/src/fake.rs:27:26
   |
27 |             column: span.column(),
   |                          ^^^^^^-- help: remove the arguments
   |                          |
   |                          field, not a method

error[E0599]: no method named `line` found for struct `proc_macro::LineColumn` in the current scope
  --> genco-macros/src/fake.rs:36:24
   |
36 |             line: span.line(),
   |                        ^^^^-- help: remove the arguments
   |                        |
   |                        field, not a method

error[E0599]: no method named `column` found for struct `proc_macro::LineColumn` in the current scope
  --> genco-macros/src/fake.rs:37:26
   |
37 |             column: span.column(),
   |                          ^^^^^^-- help: remove the arguments
   |                          |
   |                          field, not a method

For more information about this error, try `rustc --explain E0599`.
error: could not compile `genco-macros` (lib) due to 4 previous errors
```

I have actually face this when compiling a repo depending on genco.
