### PR TITLE
Update to syn 2

### DIFF
--- a/genco-macros/Cargo.toml
+++ b/genco-macros/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["code-generation", "template"]
 categories = ["template-engine"]
 
 [dependencies]
-syn = { version = "1.0.31", features = ["full"] }
+syn = { version = "2.0.38", features = ["full"] }
 q = { package = "quote", version = "1.0.3" }
 proc-macro2 = { version = "1.0.10", features = ["span-locations"] }
 

--- a/genco-macros/src/ast.rs
+++ b/genco-macros/src/ast.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use proc_macro2::{Span, TokenStream, TokenTree};
-use syn::{spanned::Spanned, Token};
+use syn::{Ident, LitChar, Token};
 
 use crate::static_buffer::StaticBuffer;
 
@@ -64,9 +64,9 @@ pub(crate) enum Name {
     /// The name is the `const` token.
     Const(Token![const]),
     /// Custom name.
-    Ident(Span, String),
+    Ident(Ident, String),
     /// Character name.
-    Char(Span, char),
+    Char(LitChar, char),
 }
 
 impl Name {
@@ -80,11 +80,12 @@ impl Name {
     }
 }
 
-impl Spanned for Name {
-    fn span(&self) -> Span {
+impl q::ToTokens for Name {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Name::Const(t) => t.span,
-            Name::Ident(span, _) | Name::Char(span, _) => *span,
+            Name::Const(t) => t.to_tokens(tokens),
+            Name::Ident(_, name) => name.to_tokens(tokens),
+            Name::Char(_, c) => c.to_tokens(tokens),
         }
     }
 }


### PR DESCRIPTION
Most of the ecosystem has moved to syn 2, which means that genco still being on syn 1 can be the cause of dependents having to compile syn twice.