### PR TITLE
Add support for variable declarations in templates

### DIFF
--- a/genco-macros/src/ast.rs
+++ b/genco-macros/src/ast.rs
@@ -182,6 +182,12 @@ pub(crate) enum Ast {
         /// Else branch of the conditional.
         else_branch: Option<TokenStream>,
     },
+    Let {
+        /// Variable name (or names for a tuple)
+        name: syn::Pat,
+        /// Expression
+        expr: syn::Expr,
+    },
     Match {
         condition: syn::Expr,
         arms: Vec<MatchArm>,

--- a/genco-macros/src/encoder.rs
+++ b/genco-macros/src/encoder.rs
@@ -115,10 +115,8 @@ impl<'a> Encoder<'a> {
                 condition, arms, ..
             } => {
                 self.encode_match(condition, arms);
-            },
-            Ast::Let {
-                name, expr
-            } => {
+            }
+            Ast::Let { name, expr } => {
                 self.encode_let(name, expr);
             }
         }

--- a/genco-macros/src/encoder.rs
+++ b/genco-macros/src/encoder.rs
@@ -115,6 +115,11 @@ impl<'a> Encoder<'a> {
                 condition, arms, ..
             } => {
                 self.encode_match(condition, arms);
+            },
+            Ast::Let {
+                name, expr
+            } => {
+                self.encode_let(name, expr);
             }
         }
 
@@ -301,6 +306,15 @@ impl<'a> Encoder<'a> {
         };
 
         self.output.extend(m);
+    }
+
+    /// Encode a let statement
+    pub(crate) fn encode_let(&mut self, name: syn::Pat, expr: syn::Expr) {
+        self.item_buffer.flush(&mut self.output);
+
+        self.output.extend(q::quote! {
+            let #name = #expr;
+        })
     }
 
     fn from(&mut self) -> Option<LineColumn> {

--- a/genco-macros/src/quote.rs
+++ b/genco-macros/src/quote.rs
@@ -253,10 +253,7 @@ impl<'a> Quote<'a> {
         input.parse::<Token![=]>()?;
         let expr = syn::Expr::parse_without_eager_brace(input)?;
 
-        let ast = Ast::Let {
-            name,
-            expr,
-        };
+        let ast = Ast::Let { name, expr };
 
         Ok((req, ast))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,7 +645,7 @@
 ///         $first and $second.
 ///     )
 /// };
-/// assert_eq!(" A and B. C and D.", tokens.to_string()?);
+/// assert_eq!("A and B.\nC and D.", tokens.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
 ///
@@ -665,7 +665,7 @@
 ///     )
 /// };
 ///
-/// assert_eq!(" First is A Second is B", tokens.to_string()?);
+/// assert_eq!("First is A\nSecond is B", tokens.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,6 +629,48 @@
 ///
 /// <br>
 ///
+/// # Variable assignment
+///
+/// You can use `$(let <binding> = <expr>)` to define variables with their value.
+/// This is useful within loops to compute values from iterator items.
+///
+/// ```
+/// use genco::prelude::*;
+///
+/// let names = ["A.B", "C.D"];
+///
+/// let tokens: Tokens<()> = quote! {
+///     $(for name in names =>
+///         $(let (first, second) = name.split_once('.').unwrap())
+///         $first and $second.
+///     )
+/// };
+/// assert_eq!(" A and B. C and D.", tokens.to_string()?);
+/// # Ok::<_, genco::fmt::Error>(())
+/// ```
+///
+/// Variables can also be mutable:
+///
+/// ```
+/// use genco::prelude::*;
+/// let path = "A.B.C.D";
+///
+/// let tokens: Tokens<()> = quote! {
+///     $(let mut items = path.split('.'))
+///     $(if let Some(first) = items.next() =>
+///         First is $first
+///     )
+///     $(if let Some(second) = items.next() =>
+///         Second is $second
+///     )
+/// };
+///
+/// assert_eq!(" First is A Second is B", tokens.to_string()?);
+/// # Ok::<_, genco::fmt::Error>(())
+/// ```
+///
+/// <br>
+///
 /// # Scopes
 ///
 /// You can use `$(ref <binding> { <expr> })` to gain access to the current

--- a/tests/test_token_gen.rs
+++ b/tests/test_token_gen.rs
@@ -348,13 +348,13 @@ fn test_let() {
     };
 
     // Function call in expression
-    let foo = "bar";
+    let x = "bar";
     fn baz(s: &str) -> String {
         format!("{s}baz")
     }
 
     let tokens: rust::Tokens = quote! {
-        $(let a = baz(foo)) $a
+        $(let a = baz(x)) $a
     };
 
     assert_eq! {
@@ -363,9 +363,9 @@ fn test_let() {
     };
 
     // Complex expression
-    let foo = 2;
+    let x = 2;
     let tokens: rust::Tokens = quote! {
-        $(let even = if foo % 2 == 0 { "even" } else { "odd" }) $even
+        $(let even = if x % 2 == 0 { "even" } else { "odd" }) $even
     };
 
     assert_eq! {
@@ -391,8 +391,18 @@ fn test_mutable_let() {
     assert_eq!(
         tokens,
         vec![
-            Push, Literal(Static("First")), Space, Literal(Static("is")), Space, Literal("A".into()),
-            Push, Literal(Static("Second")), Space, Literal(Static("is")), Space, Literal("B".into())
+            Push,
+            Literal(Static("First")),
+            Space,
+            Literal(Static("is")),
+            Space,
+            Literal("A".into()),
+            Push,
+            Literal(Static("Second")),
+            Space,
+            Literal(Static("is")),
+            Space,
+            Literal("B".into())
         ]
     );
 }


### PR DESCRIPTION
Adds support for variable declarations in `quote!` templates.

This is useful within loops to compute values from iterator items. Example:

```rust
let names = ["A.B", "C.D"];

let tokens: Tokens<()> = quote! {
    $(for name in names =>
        $(let (first, second) = name.split_once('.').unwrap())
        $first and $second.
    )
};
```