### PR TITLE
Fix a lang nix with function edge case

### DIFF
--- a/src/fmt/formatter.rs
+++ b/src/fmt/formatter.rs
@@ -305,7 +305,7 @@ impl<'a> Formatter<'a> {
     }
 }
 
-impl<'a> std::fmt::Write for Formatter<'a> {
+impl std::fmt::Write for Formatter<'_> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         if !s.is_empty() {
             Formatter::write_str(self, s)?;
@@ -315,7 +315,7 @@ impl<'a> std::fmt::Write for Formatter<'a> {
     }
 }
 
-impl<'a> std::fmt::Debug for Formatter<'a> {
+impl std::fmt::Debug for Formatter<'_> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fmt.debug_struct("Formatter")
             .field("line", &self.line)

--- a/src/lang/nix.rs
+++ b/src/lang/nix.rs
@@ -146,7 +146,10 @@ impl Nix {
                     }
                 }
                 Import::With(with) => {
-                    arguments.insert(with.argument.to_string());
+                    let argument = with.argument.split('.').next();
+                    if let Some(a) = argument {
+                        arguments.insert(a.to_string());
+                    }
                 }
             }
         }
@@ -356,8 +359,8 @@ where
 /// ```
 /// use genco::prelude::*;
 ///
-/// let concat_map = nix::with("lib", "concatMap");
-/// let list_to_attrs = nix::with("lib", "listToAttrs");
+/// let concat_map = nix::with("inputs.nixpkgs.lib", "concatMap");
+/// let list_to_attrs = nix::with("inputs.nixpkgs.lib", "listToAttrs");
 ///
 /// let toks = quote! {
 ///     $list_to_attrs $concat_map
@@ -366,11 +369,11 @@ where
 /// assert_eq!(
 ///     vec![
 ///         "{",
-///         "    lib,",
+///         "    inputs,",
 ///         "    ...",
 ///         "}:",
 ///         "",
-///         "with lib;",
+///         "with inputs.nixpkgs.lib;",
 ///         "",
 ///         "listToAttrs concatMap",
 ///     ],

--- a/src/tokens/format_into.rs
+++ b/src/tokens/format_into.rs
@@ -70,7 +70,7 @@ where
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L> FormatInto<L> for &'a Tokens<L>
+impl<L> FormatInto<L> for &Tokens<L>
 where
     L: Lang,
 {
@@ -126,7 +126,7 @@ where
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L, T> FormatInto<L> for &'a [T]
+impl<L, T> FormatInto<L> for &[T]
 where
     L: Lang,
     T: Clone + FormatInto<L>,
@@ -153,7 +153,7 @@ where
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L> FormatInto<L> for &'a str
+impl<L> FormatInto<L> for &str
 where
     L: Lang,
 {
@@ -177,7 +177,7 @@ where
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L> FormatInto<L> for &'a String
+impl<L> FormatInto<L> for &String
 where
     L: Lang,
 {
@@ -253,7 +253,7 @@ where
 /// assert_eq!("foo bar baz", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L> FormatInto<L> for &'a Rc<String>
+impl<L> FormatInto<L> for &Rc<String>
 where
     L: Lang,
 {
@@ -276,7 +276,7 @@ where
 /// assert_eq!("Hello John", result.to_string()?);
 /// # Ok::<_, genco::fmt::Error>(())
 /// ```
-impl<'a, L> FormatInto<L> for Arguments<'a>
+impl<L> FormatInto<L> for Arguments<'_>
 where
     L: Lang,
 {

--- a/src/tokens/item_str.rs
+++ b/src/tokens/item_str.rs
@@ -26,7 +26,7 @@ where
     }
 }
 
-impl<'a, L> FormatInto<L> for &'a ItemStr
+impl<L> FormatInto<L> for &ItemStr
 where
     L: Lang,
 {


### PR DESCRIPTION
Hi @udoprog, find a small bug in lang nix with function. Here is the fix.

# Problem
Currently it outputs
```nix
{
    inputs.nixpkgs,
    ...
}:

with inputs.nixpkgs;
```
which the correct output should be
```nix
{
    inputs,
    ...
}:

with inputs.nixpkgs;
```
# Solution
When the first argument contains a dot character
```
let concat_map = nix::with("inputs.nixpkgs.lib", "concatMap");
```
we should only get the first item of `split('.')` for arguments.
```nix
# The arguments should be:
{
    inputs,
    ...
}:
```