### PR TITLE
Add Kotlin Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,24 +13,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@1.66
+    - run: cargo build --workspace --lib
+    - run: cargo build --workspace --lib --no-default-features --features alloc
+
   test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        rust: ['1.66', stable, nightly]
+        rust: [stable, nightly]
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{matrix.rust}}
-    - run: cargo build --workspace
-    - run: cargo build --workspace --no-default-features --features alloc
     - run: cargo build --workspace --all-targets
       if: matrix.rust == 'stable'
-    - run: cargo test --workspace --doc
-      if: matrix.rust == 'nightly'
     - run: cargo test --workspace --all-targets
+      if: matrix.rust == 'nightly'
+    - run: cargo test --workspace --doc
       if: matrix.rust == 'nightly'
 
   clippy:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ The following are languages which have built-in support in genco.
 * [☕ <b>Java</b>][java]<br>
   <small>[Example][java-example]</small>
 
+* [🧬 <b>Kotlin</b>][kotlin]<br>
+  <small>[Example][kotlin-example]</small>
+
 * [🎼 <b>C#</b>][c#]<br>
   <small>[Example][c#-example]</small>
 
@@ -141,6 +144,8 @@ fn main() {
 [interpolate]: https://docs.rs/genco/latest/genco/macro.quote.html#quoted-string-interpolation
 [java-example]: https://github.com/udoprog/genco/blob/master/examples/java.rs
 [java]: https://docs.rs/genco/latest/genco/lang/java/index.html
+[kotlin-example]: https://github.com/udoprog/genco/blob/master/examples/kotlin.rs
+[kotlin]: https://docs.rs/genco/latest/genco/lang/kotlin/index.html
 [js-example]: https://github.com/udoprog/genco/blob/master/examples/js.rs
 [js]: https://docs.rs/genco/latest/genco/lang/js/index.html
 [Open an issue!]: https://github.com/udoprog/genco/issues/new

--- a/examples/kotlin.rs
+++ b/examples/kotlin.rs
@@ -1,0 +1,27 @@
+use genco::fmt;
+use genco::prelude::*;
+use genco::lang::kotlin;
+
+fn main() -> anyhow::Result<()> {
+    let greeter_ty = &kotlin::import("com.example.utils", "Greeter");
+
+    let tokens: kotlin::Tokens = quote! {
+        fun main() {
+            val greeter = $greeter_ty("Hello Kotlin from Genco!");
+            println(greeter.greet());
+        }
+    };
+    
+    let stdout = std::io::stdout();
+    let mut w = fmt::IoWriter::new(stdout.lock());
+    
+    let fmt_config = fmt::Config::from_lang::<kotlin::Kotlin>()
+        .with_indentation(fmt::Indentation::Space(4))
+        .with_newline("\n");
+    
+    let lang_config = kotlin::Config::default().with_package("com.example");
+    
+    tokens.format_file(&mut w.as_formatter(&fmt_config), &lang_config)?;
+
+    Ok(())
+}

--- a/src/lang/kotlin/mod.rs
+++ b/src/lang/kotlin/mod.rs
@@ -21,7 +21,7 @@ use core::fmt::Write as _;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
-
+use std::println;
 use crate as genco;
 use crate::fmt;
 use crate::tokens::ItemStr;
@@ -41,6 +41,24 @@ impl_lang! {
         type Format = Format;
         type Item = Import;
 
+        fn start_string_eval(
+            out: &mut fmt::Formatter<'_>,
+            _config: &Self::Config,
+            _format: &Self::Format,
+        ) -> fmt::Result {
+            out.write_str("${")?;
+            Ok(())
+        }
+
+        fn end_string_eval(
+            out: &mut fmt::Formatter<'_>,
+            _config: &Self::Config,
+            _format: &Self::Format,
+        ) -> fmt::Result {
+            out.write_char('}')?;
+            Ok(())
+        }
+
         fn write_quoted(out: &mut fmt::Formatter<'_>, input: &str) -> fmt::Result {
             // See: https://kotlinlang.org/docs/basic-types.html#escaped-strings
             for c in input.chars() {
@@ -52,7 +70,6 @@ impl_lang! {
                     '\'' => out.write_str("\\'")?,
                     '"' => out.write_str("\\\"")?,
                     '\\' => out.write_str("\\\\")?,
-                    '$' => out.write_str("\\$")?, // Dollar sign for string templates
                     c if c.is_ascii() && !c.is_control() => out.write_char(c)?,
                     c => {
                         // Encode non-ascii characters as UTF-16 surrogate pairs

--- a/src/lang/kotlin/mod.rs
+++ b/src/lang/kotlin/mod.rs
@@ -1,0 +1,257 @@
+//! Specialization for Kotlin code generation.
+//!
+//! # String Quoting in Kotlin
+//!
+//! Since Kotlin runs on the JVM, it also uses UTF-16 internally. String
+//! quoting for high unicode characters is done through surrogate pairs, as
+//! seen with the 😊 emoji below. Kotlin also requires escaping `$` characters
+//! in standard string literals.
+//!
+//! ```rust
+//! use genco::prelude::*;
+//!
+//! # fn main() -> genco::fmt::Result {
+//! let toks: kotlin::Tokens = quote!("start π 😊 $var \n end");
+//! assert_eq!("\"start \\u03c0 \\ud83d\\ude0a \\$var \\n end\"", toks.to_string()?);
+//! # Ok(())
+//! # }
+//! ```
+
+use core::fmt::Write as _;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::string::{String, ToString};
+
+use crate as genco;
+use crate::fmt;
+use crate::tokens::ItemStr;
+use crate::{quote_in};
+
+/// Tokens container specialized for Kotlin.
+pub type Tokens = crate::Tokens<Kotlin>;
+
+// This trait implementation signals to genco that the Kotlin language
+// supports evaluation constructs like `$(if ...)` in `quote!`.
+impl genco::lang::LangSupportsEval for Kotlin {}
+
+impl_lang! {
+    /// Language specialization for Kotlin.
+    pub Kotlin {
+        type Config = Config;
+        type Format = Format;
+        type Item = Import;
+
+        fn write_quoted(out: &mut fmt::Formatter<'_>, input: &str) -> fmt::Result {
+            // See: https://kotlinlang.org/docs/basic-types.html#escaped-strings
+            for c in input.chars() {
+                match c {
+                    '\t' => out.write_str("\\t")?,
+                    '\u{0008}' => out.write_str("\\b")?, // Backspace
+                    '\n' => out.write_str("\\n")?,
+                    '\r' => out.write_str("\\r")?,
+                    '\'' => out.write_str("\\'")?,
+                    '"' => out.write_str("\\\"")?,
+                    '\\' => out.write_str("\\\\")?,
+                    '$' => out.write_str("\\$")?, // Dollar sign for string templates
+                    c if c.is_ascii() && !c.is_control() => out.write_char(c)?,
+                    c => {
+                        // Encode non-ascii characters as UTF-16 surrogate pairs
+                        for c in c.encode_utf16(&mut [0u16; 2]) {
+                            write!(out, "\\u{:04x}", c)?;
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        fn format_file(
+            tokens: &Tokens,
+            out: &mut fmt::Formatter<'_>,
+            config: &Self::Config,
+        ) -> fmt::Result {
+            let mut header = Tokens::new();
+            let mut format = Format::default();
+
+            if let Some(ref package) = config.package {
+                // package declarations in Kotlin do not have semicolons
+                quote_in!(header => package $package);
+                header.line();
+            }
+
+            Self::imports(&mut header, tokens, config, &mut format.imported);
+            header.format(out, config, &format)?;
+            tokens.format(out, config, &format)?;
+            Ok(())
+        }
+    }
+
+    Import {
+        fn format(&self, out: &mut fmt::Formatter<'_>, config: &Config, format: &Format) -> fmt::Result {
+            let file_package = config.package.as_ref().map(|p| p.as_ref());
+            let imported = format.imported.get(self.name.as_ref()).map(String::as_str);
+            let current_package = Some(self.package.as_ref());
+
+            // Determine if we need to use the fully qualified name (FQN).
+            // Use FQN if the class is not in the current package and has not been imported.
+            // Or if a class with the same name has been imported from a different package.
+            if file_package != current_package && imported != current_package {
+                out.write_str(self.package.as_ref())?;
+                out.write_str(".")?;
+            }
+
+            out.write_str(&self.name)?;
+            Ok(())
+        }
+    }
+}
+
+/// Formatting state for Kotlin.
+#[derive(Debug, Default)]
+pub struct Format {
+    /// Types which have been imported into the local namespace.
+    /// Maps a simple name to its full package.
+    imported: BTreeMap<String, String>,
+}
+
+/// Configuration for Kotlin.
+#[derive(Debug, Default)]
+pub struct Config {
+    /// Package to use.
+    package: Option<ItemStr>,
+}
+
+impl Config {
+    /// Configure package to use for the file generated.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use genco::prelude::*;
+    /// use genco::fmt;
+    ///
+    /// let list = kotlin::import("kotlin.collections", "List");
+    ///
+    /// let toks = quote!($list);
+    ///
+    /// let config = kotlin::Config::default().with_package("com.example");
+    /// let fmt = fmt::Config::from_lang::<Kotlin>();
+    ///
+    /// let mut w = fmt::VecWriter::new();
+    ///
+    /// toks.format_file(&mut w.as_formatter(&fmt), &config)?;
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         "package com.example",
+    ///         "",
+    ///         "import kotlin.collections.List",
+    ///         "",
+    ///         "List",
+    ///     ],
+    ///     w.into_vec(),
+    /// );
+    /// # Ok::<_, genco::fmt::Error>(())
+    /// ```
+    pub fn with_package<P>(self, package: P) -> Self
+    where
+        P: Into<ItemStr>,
+    {
+        Self {
+            package: Some(package.into()),
+        }
+    }
+}
+
+/// An import of a Kotlin type, like `import kotlin.collections.List`.
+///
+/// Created through the [import()] function.
+#[derive(Debug, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub struct Import {
+    /// Package of the class.
+    package: ItemStr,
+    /// Name of the class.
+    name: ItemStr,
+}
+
+impl Kotlin {
+    /// Gathers and writes import statements to the header.
+    fn imports(
+        out: &mut Tokens,
+        tokens: &Tokens,
+        config: &Config,
+        imported: &mut BTreeMap<String, String>,
+    ) {
+        let mut to_import = BTreeSet::new();
+        let file_package = config.package.as_ref().map(|p| p.as_ref());
+
+        for import in tokens.walk_imports() {
+            // Don't import if the type is in the current package
+            if Some(import.package.as_ref()) == file_package {
+                continue;
+            }
+
+            // Don't import if a class with the same name is already imported from another package.
+            if let Some(existing_package) = imported.get(import.name.as_ref()) {
+                if existing_package != import.package.as_ref() {
+                    continue;
+                }
+            }
+
+            to_import.insert(import.clone());
+        }
+
+        if to_import.is_empty() {
+            return;
+        }
+
+        for import in to_import {
+            // import statements in Kotlin do not have semicolons
+            quote_in!(*out => import $(&import.package).$(&import.name));
+            out.push();
+            imported.insert(import.name.to_string(), import.package.to_string());
+        }
+
+        out.line();
+    }
+    
+}
+
+/// Create a new Kotlin import.
+///
+/// # Examples
+///
+/// ```
+/// use genco::prelude::*;
+///
+/// let list = kotlin::import("kotlin.collections", "List");
+/// let map = kotlin::import("kotlin.collections", "Map");
+///
+/// let toks = quote! {
+///     val a: $list<String>
+///     val b: $map<String, Int>
+/// };
+///
+/// assert_eq!(
+///     vec![
+///         "import kotlin.collections.List",
+///         "import kotlin.collections.Map",
+///         "",
+///         "val a: List<String>",
+///         "val b: Map<String, Int>",
+///     ],
+///     toks.to_file_vec()?
+/// );
+/// # Ok::<_, genco::fmt::Error>(())
+/// ```
+pub fn import<P, N>(package: P, name: N) -> Import
+where
+    P: Into<ItemStr>,
+    N: Into<ItemStr>,
+{
+    Import {
+        package: package.into(),
+        name: name.into(),
+    }
+}

--- a/src/lang/kotlin/mod.rs
+++ b/src/lang/kotlin/mod.rs
@@ -21,7 +21,6 @@ use core::fmt::Write as _;
 
 use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
-use std::println;
 use crate as genco;
 use crate::fmt;
 use crate::tokens::ItemStr;

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -22,6 +22,8 @@ pub mod csharp;
 pub mod dart;
 pub mod go;
 pub mod java;
+
+pub mod kotlin;
 pub mod js;
 pub mod nix;
 pub mod python;
@@ -33,6 +35,7 @@ pub use self::csharp::Csharp;
 pub use self::dart::Dart;
 pub use self::go::Go;
 pub use self::java::Java;
+pub use self::kotlin::Kotlin;
 pub use self::js::JavaScript;
 pub use self::nix::Nix;
 pub use self::python::Python;


### PR DESCRIPTION
This PR adds `Kotlin` support to `genco`

You can try it out with the following example:

```
cargo run --example kotlin
```